### PR TITLE
Modernize codebase for Python 3.8+ and current biopython/pandas

### DIFF
--- a/CSpred.py
+++ b/CSpred.py
@@ -1,210 +1,224 @@
 #!/usr/bin/env python3
-# Script for making predictions using both the X module and the Y module
+# UCBShift chemical shift predictor — main entry point.
+# Combines UCBShift-X (ML) and UCBShift-Y (transfer) predictions.
 
-# Author: Jie Li
-# Date created: Sep 20, 2019
+import os
+import sys
+import argparse
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import joblib
 
 from spartap_features import PDB_SPARTAp_DataReader
-from data_prep_functions import *
+from data_prep_functions import (
+    ha23ambigfix, Add_res_spec_feats, feat_pwr,
+    hbondd_cols, cos_cols,
+    dssp_pp_cols, dssp_energy_cols,
+    rcoil_cols, ring_cols,
+    sparta_rename_map,
+)
 import ucbshifty
-import joblib
 import toolbox
-import os
-import pandas as pd
-import argparse
-import multiprocessing
-# import warnings
-import sys
-if sys.version_info.major < 3 or sys.version_info.major == 3 and sys.version_info.minor < 5:
-    raise ValueError("Python >= 3.5 required")
 
+if sys.version_info < (3, 8):
+    raise RuntimeError("Python >= 3.8 required")
 
-# Suppress Setting With Copy warnings
 pd.options.mode.chained_assignment = None
 
-SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
-ML_MODEL_PATH = SCRIPT_PATH + "/models/"
+SCRIPT_PATH = Path(os.path.dirname(os.path.realpath(__file__)))
+ML_MODEL_PATH = SCRIPT_PATH / "models"
 
-def build_input(pdb_file_name, pH=5, rcfeats=True, hse=True, hbrad=[5.0] * 3):
-    '''
-    Function for building dataframe for the specified pdb file.
-    Returns a pandas dataframe for a specific single-chain pdb file.
 
-    args:
-        pdb_file_name = The path to the PDB file for prediction (str)
-        pH = pH value to be considered
-        rcfeats = Include a column for random coil chemical shifts (Bool)
-        hse = Include a feature column for the half-sphere exposure (Bool)
-        hbrad = Max length of hydrogen bonds for HA,HN and O (list of float)
-    '''
-    # Build feature reader and read all features
-    feature_reader = PDB_SPARTAp_DataReader()
-    pdb_data = feature_reader.df_from_file_3res(pdb_file_name,rcshifts=rcfeats, hse=hse, first_chain_only=False, sequence_columns=0,hbrad=hbrad)
-    pdb_data["pH"]=pH
+def build_input(
+    pdb_file_name: str,
+    pH: float = 5.0,
+    rcfeats: bool = True,
+    hse: bool = True,
+    hbrad: Optional[list] = None,
+) -> pd.DataFrame:
+    """Extract SPARTA+ features from *pdb_file_name* and return a DataFrame."""
+    if hbrad is None:
+        hbrad = [5.0, 5.0, 5.0]
+    reader = PDB_SPARTAp_DataReader()
+    pdb_data = reader.df_from_file_3res(
+        pdb_file_name, rcshifts=rcfeats, hse=hse,
+        first_chain_only=False, sequence_columns=0, hbrad=hbrad,
+    )
+    pdb_data["pH"] = pH
     return pdb_data
 
-def data_preprocessing(data):
-    '''
-    Function for executing all the preprocessing steps based on the original extracted features, including fixing HA2/HA3 ring current ambiguity, adding hydrophobicity, powering features, drop unnecessary columns, etc.
-    '''
+
+def data_preprocessing(data: pd.DataFrame) -> pd.DataFrame:
+    """Apply all preprocessing steps: HA2/HA3 fix, hydrophobicity, power features, column drops."""
     data = data.copy()
     data = data[sorted(data.columns)]
     data = ha23ambigfix(data, mode=0)
     Add_res_spec_feats(data, include_onehot=False)
     data = feat_pwr(data, hbondd_cols + cos_cols, [2])
-    data = feat_pwr(data, hbondd_cols, [-1,-2,-3])
-    dropped_cols = dssp_pp_cols + dssp_energy_cols + ['Unnamed: 0', 'Unnamed: 0.1', 'Unnamed: 0.1.1', 'FILE_ID', 'PDB_FILE_NAME', 'RESNAME', 'RES_NUM',"RES", 'CHAIN', 'RESNAME_ip1', 'RESNAME_im1', 'BMRB_RES_NUM', 'CG', 'RCI_S2', 'MATCHED_BMRB',"identifier"]+ rcoil_cols
-    data = data.drop(set(dropped_cols) & set(data.columns), axis=1)
+    data = feat_pwr(data, hbondd_cols, [-1, -2, -3])
+    dropped = set(dssp_pp_cols + dssp_energy_cols + rcoil_cols + [
+        'Unnamed: 0', 'Unnamed: 0.1', 'Unnamed: 0.1.1',
+        'FILE_ID', 'PDB_FILE_NAME', 'RESNAME', 'RES_NUM', 'RES',
+        'CHAIN', 'RESNAME_ip1', 'RESNAME_im1', 'BMRB_RES_NUM',
+        'CG', 'RCI_S2', 'MATCHED_BMRB', 'identifier',
+    ])
+    data = data.drop(dropped & set(data.columns), axis=1)
     return data
 
-def prepare_data_for_atom(data,atom):
-    '''
-    Function to generate features data for a given atom type: meaning that the irrelevant ring current values are removed from features
 
-    args:
-        data - the dataset that contains all the features (pandas.DataFrame)
-        atom - the atom to keep ring currents
-
-    returns:
-        pandas.DataFrame containing the cleaned feature set
-    '''
+def prepare_data_for_atom(data: pd.DataFrame, atom: str) -> pd.DataFrame:
+    """Keep only the ring-current column relevant to *atom*; zero-fill NaNs."""
     dat = data.copy()
     ring_col = atom + '_RC'
-    rem1 = ring_cols.copy()
-    rem1.remove(ring_col)
-    dat = dat.drop(rem1, axis=1)
-    dat[ring_col] = dat[ring_col].fillna(value=0)
+    cols_to_remove = [c for c in ring_cols if c != ring_col]
+    dat = dat.drop([c for c in cols_to_remove if c in dat.columns], axis=1)
+    dat[ring_col] = dat[ring_col].fillna(0)
     return dat
 
-def calc_sing_pdb(pdb_file_name,pH=5,TP=True,TP_pred=None,ML=True,test=False):
-    '''
-    Function for calculating chemical shifts for a single PDB file using X module / Y module / both
 
-    args:
-        pdb_file_name = The path to the PDB file for prediction (str)
-        pH = pH value to be considered
-        TP = Whether or not use TP module (Bool)
-        TP_pred = predicted shifts dataframe from Y module. If None, generate this prediction within this function (pandas.DataFrame / None)
-        ML = Whether or not use ML module (Bool)
-        test = Whether or not use test mode (Exclude mode for SHIFTY++, Bool)
-    '''
-    if not os.path.isdir(ML_MODEL_PATH):
-        raise ValueError("models not installed in {}".format(ML_MODEL_PATH))
+def calc_sing_pdb(
+    pdb_file_name: str,
+    pH: float = 5.0,
+    TP: bool = True,
+    TP_pred: Optional[pd.DataFrame] = None,
+    ML: bool = True,
+    test: bool = False,
+) -> pd.DataFrame:
+    """Predict chemical shifts for a single PDB file.
+
+    TP  — use UCBShift-Y (transfer prediction) module
+    ML  — use UCBShift-X (machine learning) module
+    test — exclude mode for UCBShift-Y (for benchmarking)
+    """
+    if not ML_MODEL_PATH.is_dir():
+        raise FileNotFoundError(f"Models directory not found: {ML_MODEL_PATH}")
     if pH < 2 or pH > 12:
-        print("Warning! Predictions for proteins in extreme pH conditions are likely to be erroneous. Take prediction results at your own risk!")
+        print("Warning! Extreme pH — predictions may be unreliable.")
+
     preds = pd.DataFrame()
+
     if TP:
         if TP_pred is None:
             print("Calculating UCBShift-Y predictions ...")
-            # generate hash string from pdb file name
-            hashed_file_name = str(hash(pdb_file_name) % ((sys.maxsize + 1) * 2)) + '/'
-            TP_pred = ucbshifty.main(pdb_file_name, 1, exclude=test, custom_working_dir=hashed_file_name)
+            hashed = str(hash(pdb_file_name) % ((sys.maxsize + 1) * 2)) + '/'
+            TP_pred = ucbshifty.main(pdb_file_name, 1, exclude=test, custom_working_dir=hashed)
         if not ML:
-            # Prepare data when only doing TP prediction
-            preds = TP_pred[["RESNUM","RESNAME"]]
+            preds = TP_pred[["RESNUM", "RESNAME"]].copy()
             for atom in toolbox.ATOMS:
-                if atom+"_RC" in TP_pred.columns:
-                    rc = TP_pred[atom+"_RC"]
-                else:
-                    rc = 0
-                preds[atom+"_Y"] = TP_pred[atom] + rc
+                rc = TP_pred[f"{atom}_RC"] if f"{atom}_RC" in TP_pred.columns else 0
+                preds[f"{atom}_Y"] = TP_pred[atom] + rc
+
     if ML:
         print("Generating features ...")
         feats = build_input(pdb_file_name, pH)
-        feats.rename(index=str, columns=sparta_rename_map, inplace=True) # Rename columns so that random coil columns can be correctly recognized
+        feats.rename(columns=sparta_rename_map, inplace=True)
         resnames = feats["RESNAME"]
         resnums = feats["RES_NUM"]
         rcoils = feats[rcoil_cols]
         feats = data_preprocessing(feats)
 
-        result = {"RESNUM":resnums, "RESNAME":resnames}
+        result: dict = {"RESNUM": resnums, "RESNAME": resnames}
         for atom in toolbox.ATOMS:
-            print("Calculating UCBShift-X predictions for %s ..." % atom)
-            # Predictions for each atom
+            print(f"Calculating UCBShift-X predictions for {atom} ...")
             atom_feats = prepare_data_for_atom(feats, atom)
-            r0 = joblib.load(ML_MODEL_PATH + "%s_R0.sav" % atom)
+            r0 = joblib.load(ML_MODEL_PATH / f"{atom}_R0.sav")
             r0_pred = r0.predict(atom_feats.values)
 
             feats_r1 = atom_feats.copy()
             feats_r1["R0_PRED"] = r0_pred
-            r1 = joblib.load(ML_MODEL_PATH + "%s_R1.sav" % atom)
+            r1 = joblib.load(ML_MODEL_PATH / f"{atom}_R1.sav")
             r1_pred = r1.predict(feats_r1.values)
-            # Write ML predictions
-            result[atom+"_X"] = r1_pred + rcoils["RCOIL_"+atom]
+            result[f"{atom}_X"] = r1_pred + rcoils[f"RCOIL_{atom}"]
 
             if TP:
-                print("Calculating UCBShift predictions for %s ..." % atom)
+                print(f"Calculating UCBShift predictions for {atom} ...")
                 feats_r2 = atom_feats.copy()
                 feats_r2["RESNAME"] = resnames
                 feats_r2["RESNUM"] = resnums
-                tp_atom = TP_pred[["RESNAME", "RESNUM", atom, atom+"_BEST_REF_SCORE", atom+"_BEST_REF_COV", atom+"_BEST_REF_MATCH"]]
-                feats_r2 = pd.merge(feats_r2, tp_atom, on="RESNUM", suffixes=("","_TP"), how="left")
-                # Write TP predictions
-                result[atom+"_Y"] = feats_r2[atom].values
-                result[atom+"_BEST_REF_SCORE"] = feats_r2[atom+"_BEST_REF_SCORE"].values
-                result[atom+"_BEST_REF_COV"] = feats_r2[atom+"_BEST_REF_COV"].values
-                result[atom+"_BEST_REF_MATCH"] = feats_r2[atom+"_BEST_REF_MATCH"].values
-                valid = (feats_r2.RESNAME == feats_r2.RESNAME_TP) & (feats_r2[atom].notnull())
-                # Subtract random coils to make secondary TP shifts
-                feats_r2[atom] -= rcoils["RCOIL_"+atom].values
+                tp_atom = TP_pred[[
+                    "RESNAME", "RESNUM", atom,
+                    f"{atom}_BEST_REF_SCORE", f"{atom}_BEST_REF_COV", f"{atom}_BEST_REF_MATCH",
+                ]]
+                feats_r2 = pd.merge(feats_r2, tp_atom, on="RESNUM", suffixes=("", "_TP"), how="left")
+                result[f"{atom}_Y"] = feats_r2[atom].values
+                result[f"{atom}_BEST_REF_SCORE"] = feats_r2[f"{atom}_BEST_REF_SCORE"].values
+                result[f"{atom}_BEST_REF_COV"] = feats_r2[f"{atom}_BEST_REF_COV"].values
+                result[f"{atom}_BEST_REF_MATCH"] = feats_r2[f"{atom}_BEST_REF_MATCH"].values
+                valid = (feats_r2.RESNAME == feats_r2.RESNAME_TP) & feats_r2[atom].notnull()
+                feats_r2[atom] -= rcoils[f"RCOIL_{atom}"].values
                 feats_r2["R0_PRED"] = r0_pred
-                valid_feats_r2 = feats_r2.drop(["RESNAME","RESNUM","RESNAME_TP"], axis=1)[valid]
+                valid_feats_r2 = feats_r2.drop(["RESNAME", "RESNUM", "RESNAME_TP"], axis=1)[valid]
                 r2_pred = r1_pred.copy()
                 if len(valid_feats_r2):
-                    r2 = joblib.load(ML_MODEL_PATH + "%s_R2.sav" % atom)
-                    r2_pred_valid = r2.predict(valid_feats_r2.values)
-                    r2_pred[valid] = r2_pred_valid
-                # Write final predictions
-                result[atom+"_UCBShift"] = r2_pred + rcoils["RCOIL_"+atom]
+                    r2 = joblib.load(ML_MODEL_PATH / f"{atom}_R2.sav")
+                    r2_pred[valid] = r2.predict(valid_feats_r2.values)
+                result[f"{atom}_UCBShift"] = r2_pred + rcoils[f"RCOIL_{atom}"]
+
         preds = pd.DataFrame(result)
     return preds
 
-        
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    args = argparse.ArgumentParser(description='This program is an NMR chemical shift predictor for protein chemical shifts (including H, Hα, C\', Cα, Cβ and N) in aqueous solution. It has two sub-modules: one is the machine learning (X) module. It uses ensemble tree-based methods to predict chemical shifts from the features extracted from the PDB files. The second sub-module is the transfer prediction (Y) module that predicts chemical shifts by "transfering" shifts from similar proteins in the database to the query protein through structure and sequence alignments. Finally, the two parts are combined to give the UCBShift predictions.')
-    args.add_argument("input", help="The query PDB file or list of PDB files for which the shifts are calculated")
-    args.add_argument("--batch", "-b", action="store_true", help="If toggled, input accepts a text file specifying all the PDB files need to be calculated (Each line is a PDB file name. If pH values are specified, followed with a space)")
-    args.add_argument("--output", "-o", help="Filename of generated output file. A file [shifts.csv] is generated by default. If in batch mode, you should specify the path for storing all the output files. Each output file has the same name as the input PDB file name.", default="shifts.csv")
-    args.add_argument("--worker", "-w", type=int, help="Number of CPU cores to use for parallel prediction in batch mode.", default=4)
-    args.add_argument("--shifty_only", "-y", "-Y", action="store_true", help="Only use UCBShift-Y (transfer prediction) module. Equivalent to executing UCBShift-Y directly with default settings")
-    args.add_argument("--shiftx_only", "-x", "-X", action="store_true", help="Only use UCBShift-X (machine learning) module. No alignment results will be utilized or calculated")
-    args.add_argument("--pH", "-pH", "-ph", type=float, help="pH value to be considered. Default is 5", default=5)
-    args.add_argument("--test", "-t", action="store_true", help="If toggled, use test mode for UCBShift-Y prediction")
-    args.add_argument("--models", help="Alternate location for models directory")
-    args = args.parse_args()
+    parser = argparse.ArgumentParser(
+        description=(
+            "UCBShift: NMR chemical shift predictor for protein backbone atoms "
+            "(H, Hα, C′, Cα, Cβ, N) in aqueous solution. Combines an ML module "
+            "(UCBShift-X) with a transfer-prediction module (UCBShift-Y)."
+        )
+    )
+    parser.add_argument("input", help="Query PDB file (or batch list if --batch is set)")
+    parser.add_argument("--batch", "-b", action="store_true",
+                        help="Input is a text file with one PDB path per line (optional pH on same line)")
+    parser.add_argument("--output", "-o", default="shifts.csv",
+                        help="Output CSV (or output directory in batch mode)")
+    parser.add_argument("--worker", "-w", type=int, default=4,
+                        help="Number of CPU cores for batch mode (currently unused)")
+    parser.add_argument("--shifty_only", "-y", "-Y", action="store_true",
+                        help="Use only UCBShift-Y (transfer prediction)")
+    parser.add_argument("--shiftx_only", "-x", "-X", action="store_true",
+                        help="Use only UCBShift-X (machine learning)")
+    parser.add_argument("--pH", "-pH", "-ph", type=float, default=5.0,
+                        help="pH value (default: 5)")
+    parser.add_argument("--test", "-t", action="store_true",
+                        help="Use test-mode BLAST database (for benchmarking)")
+    parser.add_argument("--models", help="Alternate path to models directory")
+    args = parser.parse_args()
+
     if args.models:
-        if not os.path.isdir(args.models):
-            raise ValueError("Directory {} specified by models does not exists".format(args.models))
-        ML_MODEL_PATH = args.models
- 
+        models_path = Path(args.models)
+        if not models_path.is_dir():
+            raise FileNotFoundError(f"Models directory not found: {args.models}")
+        ML_MODEL_PATH = models_path
+
     if not args.batch:
-        preds = calc_sing_pdb(args.input, args.pH, TP=not args.shiftx_only, ML=not args.shifty_only, test=args.test)
-        preds.to_csv(args.output, index=None)
+        preds = calc_sing_pdb(
+            args.input, args.pH,
+            TP=not args.shiftx_only, ML=not args.shifty_only, test=args.test,
+        )
+        preds.to_csv(args.output, index=False)
     else:
         inputs = []
         with open(args.input) as f:
             for line in f:
-                line_content = line.split()
-                if len(line_content) == 1:
-                    # No pH values explicitly specified. Use the global pH values
-                    line_content.append(args.pH)
+                parts = line.split()
+                if len(parts) == 1:
+                    parts.append(args.pH)
                 else:
-                    line_content[-1] = float(line_content[-1])
-                inputs.append(line_content)
-        # Decide saving folder
-        if args.output == "shifts.csv":
-            # No specific output path specified. Store all files in the current folder
-            SAVE_PREFIX = ""
-        else:
-            SAVE_PREFIX = args.output
-            if SAVE_PREFIX[-1] != "/":
-                SAVE_PREFIX = SAVE_PREFIX + "/"
+                    parts[-1] = float(parts[-1])
+                inputs.append(parts)
 
-        for idx, item in enumerate(inputs):
-            preds = calc_sing_pdb(item[0], item[1], TP=not args.shiftx_only, ML=not args.shifty_only, test=args.test)
-            preds.to_csv(SAVE_PREFIX + os.path.basename(item[0]).replace(".pdb", ".csv"), index=None)
-            print("Finished prediction for %s (%d/%d)" % (item[0], idx + 1, len(inputs)))    
-    
+        save_prefix = "" if args.output == "shifts.csv" else args.output.rstrip("/") + "/"
+        for idx, (pdb_file, ph) in enumerate(inputs):
+            preds = calc_sing_pdb(
+                pdb_file, ph,
+                TP=not args.shiftx_only, ML=not args.shifty_only, test=args.test,
+            )
+            out_name = save_prefix + os.path.basename(pdb_file).replace(".pdb", ".csv")
+            preds.to_csv(out_name, index=False)
+            print(f"Finished prediction for {pdb_file} ({idx + 1}/{len(inputs)})")
+
     print("Complete!")
-   

--- a/data_prep_functions.py
+++ b/data_prep_functions.py
@@ -1,54 +1,53 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Sun Nov 18 14:07:26 2018
-
-@author: bennett
-"""
 
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-from Bio.SeqUtils import IUPACData
 
+try:
+    from Bio.Data import IUPACData
+except ImportError:
+    from Bio.SeqUtils import IUPACData  # biopython < 1.80
 
-
-# First define some prelimnary things
+from typing import Optional
 
 atom_names = ['HA', 'H', 'CA', 'CB', 'C', 'N']
-sparta_results = [0.25, 0.49, 0.94, 1.14, 1.09, 2.45] # Advertised performance of SPARTA+
-paper_order = ['Ala', 'Cys','Asp','Glu','Phe','Gly','His','Ile','Lys','Leu','Met','Asn','Pro','Gln','Arg','Ser','Thr','Val','Trp','Tyr'] # The amino acid order used in Sparta+ data and blosum matrix (1-letter alphabetic).
 
-# The dictionary storing the hydrophobicity for different residues
-# Literature: Wimley WC & White SH (1996). Nature Struct. Biol. 3:842-848. 
-hydrophobic_dict={'LYS': 1.81, 'GLN': 0.19, 'THR': 0.11, 'ASP': 0.5, 'GLU': 0.12, 'ARG': 1.0, 'LEU': -0.69, 'TRP': -0.24, 'VAL': -0.53, 
-'ILE': -0.81, 'PRO': -0.31, 'MET': -0.44, 'ASN': 0.43, 'SER': 0.33, 'ALA': 0.33, 'GLY': 1.14, 'TYR': 0.23, 'HIS': -0.06, 'PHE': -0.58, 'CYS': 0.22}
+paper_order = ['ALA', 'CYS', 'ASP', 'GLU', 'PHE', 'GLY', 'HIS', 'ILE',
+               'LYS', 'LEU', 'MET', 'ASN', 'PRO', 'GLN', 'ARG', 'SER',
+               'THR', 'VAL', 'TRP', 'TYR']
 
-# For easier access, define the names of different feature columns.
-# These are the names that we assign in our own feature extraction routine.
-col_phipsi = [i+j for i in ['PHI_', 'PSI_'] for j in ['COS_i-1', 'SIN_i-1']]
-col_phipsi += [i+j for i in ['PHI_', 'PSI_'] for j in ['COS_i', 'SIN_i']]
-col_phipsi += [i+j for i in ['PHI_', 'PSI_'] for j in ['COS_i+1', 'SIN_i+1']]
-col_chi = [i+j+k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-col_hbprev = ['O_'+i+'_i-1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
-col_hbond = [i+j+'_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
-col_hbnext = ['HN_'+i+'_i+1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
-col_s2 = ['S2'+i for i in ['_i-1', '_i', '_i+1']]
+# Wimley WC & White SH (1996). Nature Struct. Biol. 3:842-848.
+hydrophobic_dict = {
+    'LYS': 1.81, 'GLN': 0.19, 'THR': 0.11, 'ASP': 0.5, 'GLU': 0.12,
+    'ARG': 1.0, 'LEU': -0.69, 'TRP': -0.24, 'VAL': -0.53, 'ILE': -0.81,
+    'PRO': -0.31, 'MET': -0.44, 'ASN': 0.43, 'SER': 0.33, 'ALA': 0.33,
+    'GLY': 1.14, 'TYR': 0.23, 'HIS': -0.06, 'PHE': -0.58, 'CYS': 0.22,
+}
+
+col_phipsi = [i + j for i in ['PHI_', 'PSI_'] for j in ['COS_i-1', 'SIN_i-1']]
+col_phipsi += [i + j for i in ['PHI_', 'PSI_'] for j in ['COS_i', 'SIN_i']]
+col_phipsi += [i + j for i in ['PHI_', 'PSI_'] for j in ['COS_i+1', 'SIN_i+1']]
+col_chi = [i + j + k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+col_hbprev = ['O_' + i + '_i-1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
+col_hbond = [i + j + '_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
+col_hbnext = ['HN_' + i + '_i+1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
+col_s2 = ['S2' + i for i in ['_i-1', '_i', '_i+1']]
 struc_cols = col_phipsi + col_chi + col_hbprev + col_hbond + col_hbnext + col_s2
-blosum_names = ['BLOSUM62_NUM_'+paper_order[i].upper() for i in range(20)]
-#blosum_names = ['BLOSUM62_NUM_'+sorted(IUPACData.protein_letters_3to1.keys())[i].upper() for i in range(20)]
-col_blosum = [blosum_names[i]+j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
+
+blosum_names = [f'BLOSUM62_NUM_{paper_order[i]}' for i in range(20)]
+col_blosum = [blosum_names[i] + j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
 seq_cols = col_blosum
-bin_seq_cols = ['BINSEQREP_'+ sorted(IUPACData.protein_letters_3to1.keys())[i].upper() + j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
+bin_seq_cols = [
+    'BINSEQREP_' + sorted(IUPACData.protein_letters_3to1.keys())[i].upper() + j
+    for j in ['_i-1', '_i', '_i+1'] for i in range(20)
+]
 rcoil_cols = ['RCOIL_' + atom for atom in atom_names]
 ring_cols = [atom + '_RC' for atom in atom_names]
 all_cols = struc_cols + seq_cols + rcoil_cols + ring_cols
 all_cols_bin = struc_cols + bin_seq_cols + rcoil_cols + ring_cols
 
-# These are the names of new columns that were not included in the SPARTA+ feature set
-hsea_names = ['HSE_CA' + i  for i in ['_U', '_D', '_Angle']]
-hseb_names = ['HSE_CB' + i  for i in ['_U', '_D']]
+hsea_names = ['HSE_CA' + i for i in ['_U', '_D', '_Angle']]
+hseb_names = ['HSE_CB' + i for i in ['_U', '_D']]
 hse_cols = [name + i for i in ['_i-1', '_i', '_i+1'] for name in hsea_names + hseb_names]
 dssp_ss_names = ['A_HELIX_SS', 'B_BRIDGE_SS', 'STRAND_SS', '3_10_HELIX_SS', 'PI_HELIX_SS', 'TURN_SS', 'BEND_SS', 'NONE_SS']
 dssp_asa_names = ['REL_ASA', 'ABS_ASA']
@@ -59,21 +58,17 @@ dssp_energy_cols = [name + i for i in ['_i-1', '_i', '_i+1'] for name in dssp_hb
 dssp_expp_cols = [name + i for i in ['_i-1', '_i', '_i+1'] for name in dssp_ss_names + dssp_asa_names + dssp_hb_names]
 dssp_ssi_cols = [name + '_i' for name in dssp_ss_names]
 dssp_norm_cols = [name + i for i in ['_i-1', '_i', '_i+1'] for name in dssp_asa_names + dssp_hb_names]
-dssp_pp_cols=[name + i for i in ['_i-1', '_i', '_i+1'] for name in dssp_pp_names]
+dssp_pp_cols = [name + i for i in ['_i-1', '_i', '_i+1'] for name in dssp_pp_names]
 
-# These are the names of the columns with sequence information beyond the tri-peptide level
-ext_seq_cols = ['RESNAME_i' + i + str(j) for i in ['+', '-'] for j in range(1,21)]
+ext_seq_cols = ['RESNAME_i' + i + str(j) for i in ['+', '-'] for j in range(1, 21)]
 
-# These column names are for renaming to make consistent between Michael's version
-# of the naming and my own
 sparta_ring_cols = [atom + '_RING' for atom in atom_names]
-sparta_rcoil_cols = ["RC_" + atom  for atom in atom_names]
+sparta_rcoil_cols = ['RC_' + atom for atom in atom_names]
 sparta_rename_cols = sparta_ring_cols + sparta_rcoil_cols
 sparta_rename_map = dict(zip(sparta_rename_cols, ring_cols + rcoil_cols))
 sx2_rcoil_cols = ['RC_' + atom for atom in atom_names]
 sx2_rename_map = dict(zip(sparta_ring_cols + sx2_rcoil_cols, ring_cols + rcoil_cols))
 
-# Define the names for the original Sparta+ Data Columns (same set as above but different order so we can assign column labels to data obtained directly from Yang)
 orig_cols = col_blosum[:20]
 orig_cols += [i + j for i in ['PHI_', 'PSI_'] for j in ['SIN_i-1', 'COS_i-1']]
 orig_cols += [i + j + '_i-1' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', 'EXISTS']]
@@ -83,21 +78,16 @@ orig_cols += [i + j + '_i' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', '
 orig_cols += col_blosum[40:]
 orig_cols += [i + j for i in ['PHI_', 'PSI_'] for j in ['SIN_i+1', 'COS_i+1']]
 orig_cols += [i + j + '_i+1' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', 'EXISTS']]
-orig_cols += ['O_'+i+'_i-1' for i in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
-orig_cols += [i+j+'_i' for i in ['HN_', 'Ha_', 'O_'] for j in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
-orig_cols += ['HN_'+i+'_i+1' for i in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
-orig_cols += ['S2'+i for i in ['_i-1', '_i', '_i+1']]
+orig_cols += ['O_' + i + '_i-1' for i in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
+orig_cols += [i + j + '_i' for i in ['HN_', 'Ha_', 'O_'] for j in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
+orig_cols += ['HN_' + i + '_i+1' for i in ['_EXISTS', 'd_HA', '_COS_A', '_COS_H']]
+orig_cols += ['S2' + i for i in ['_i-1', '_i', '_i+1']]
 
-# These are the names of the boolean columns in the Sparta+ features that indicate existance of chi1/chi2 angles as well as possible hydrogen bonds
 exist_cols = [i + 'EXISTS' + k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_']]
-exist_cols += ['O_'+ '_EXISTS' +'_i-1', 'HN_' + '_EXISTS' + '_i+1']
+exist_cols += ['O__EXISTS_i-1', 'HN__EXISTS_i+1']
 exist_cols += [i + '_EXISTS' + '_i' for i in ['Ha_', 'HN_', 'O_']]
-# For completeness, here are the remaining columns
-non_exist_cols = orig_cols.copy()
-for x in exist_cols:
-    non_exist_cols.remove(x)
+non_exist_cols = [c for c in orig_cols if c not in exist_cols]
 
-# These columns are multiplied by 10 in the original Sparta+ data
 x10cols = [i + j for i in ['PHI_', 'PSI_'] for j in ['SIN_i-1', 'COS_i-1']]
 x10cols += [i + j + '_i-1' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', 'EXISTS']]
 x10cols += [i + j for i in ['PHI_', 'PSI_'] for j in ['SIN_i', 'COS_i']]
@@ -105,33 +95,27 @@ x10cols += [i + j + '_i' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', 'EX
 x10cols += [i + j for i in ['PHI_', 'PSI_'] for j in ['SIN_i+1', 'COS_i+1']]
 x10cols += [i + j + '_i+1' for i in ['CHI1_', 'CHI2_'] for j in ['SIN', 'COS', 'EXISTS']]
 
-# Make separate lists of cosine, sine, distance columns
 phipsicos_cols = [i + 'COS_i-1' for i in ['PHI_', 'PSI_']]
 phipsicos_cols += [i + 'COS_i' for i in ['PHI_', 'PSI_']]
 phipsicos_cols += [i + 'COS_i+1' for i in ['PHI_', 'PSI_']]
 chicos_cols = [i + 'COS' + k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_']]
-hbondcos_cols = ['O_'+i+'_i-1' for i in ['_COS_H', '_COS_A']]
-hbondcos_cols += [i+j+'_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['_COS_H', '_COS_A']]
-hbondcos_cols += ['HN_'+i+'_i+1' for i in ['_COS_H', '_COS_A']]
+hbondcos_cols = ['O_' + i + '_i-1' for i in ['_COS_H', '_COS_A']]
+hbondcos_cols += [i + j + '_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['_COS_H', '_COS_A']]
+hbondcos_cols += ['HN_' + i + '_i+1' for i in ['_COS_H', '_COS_A']]
 cos_cols = phipsicos_cols + chicos_cols + hbondcos_cols
 phipsisin_cols = [i + 'SIN_i-1' for i in ['PHI_', 'PSI_']]
 phipsisin_cols += [i + 'SIN_i' for i in ['PHI_', 'PSI_']]
 phipsisin_cols += [i + 'SIN_i-1' for i in ['PHI_', 'PSI_']]
 chisin_cols = [i + 'SIN' + k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_']]
 sin_cols = phipsisin_cols + chisin_cols
-# And a list for columns containing distance information
 hbondd_cols = ['O_d_HA_i-1']
-hbondd_cols += [i+'d_HA_i' for i in ['Ha_', 'HN_', 'O_']]
+hbondd_cols += [i + 'd_HA_i' for i in ['Ha_', 'HN_', 'O_']]
 hbondd_cols += ['HN_d_HA_i+1']
 
-# Need a list of columns that will be subject to noise if we wish to use noise injection
 angle_cols = cos_cols + sin_cols
 noisy_cols = angle_cols + hbondd_cols + col_s2
 
-# Lets try some nonlinear functions of these columns
-# Define columns to be squared
 square_cols = cos_cols + hbondd_cols + col_s2
-#square_cols_names = [x + '_sq' for x in square_cols]
 square_cols_names = [x + '^2.0' for x in square_cols]
 cols_pown1 = hbondd_cols
 cols_pown2 = hbondd_cols
@@ -140,303 +124,202 @@ col_names_pown1 = [x + '^-1.0' for x in cols_pown1]
 col_names_pown2 = [x + '^-2.0' for x in cols_pown2]
 col_names_pown3 = [x + '^-3.0' for x in cols_pown3]
 
-# Define the names for the _i+1 and _i-1 columns to allow dropping them for RNNs
-im1_cols = ['PSI_'+i for i in ['COS_i-1', 'SIN_i-1']]
-ip1_cols = ['PHI_'+i for i in ['COS_i+1', 'SIN_i+1']]
-im1_cols += [i+j+'_i-1' for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-ip1_cols += [i+j+'_i+1' for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+im1_cols = ['PSI_' + i for i in ['COS_i-1', 'SIN_i-1']]
+ip1_cols = ['PHI_' + i for i in ['COS_i+1', 'SIN_i+1']]
+im1_cols += [i + j + '_i-1' for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+ip1_cols += [i + j + '_i+1' for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
 im1_cols += col_hbprev
 ip1_cols += col_hbnext
 im1_cols += ['S2_i-1']
 ip1_cols += ['S2_i+1']
-im1_cols_bin = im1_cols.copy()
-ip1_cols_bin = ip1_cols.copy()
-im1_cols += ['BLOSUM62_NUM_'+list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i-1' for i in range(20)]
-ip1_cols += ['BLOSUM62_NUM_'+list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i+1' for i in range(20)]
-im1_cols_bin += ['BINSEQREP_'+ list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i-1' for i in range(20)]
-ip1_cols_bin += ['BINSEQREP_'+ list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i+1' for i in range(20)]
+im1_cols_bin = list(im1_cols)
+ip1_cols_bin = list(ip1_cols)
+im1_cols += [
+    'BLOSUM62_NUM_' + list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i-1'
+    for i in range(20)
+]
+ip1_cols += [
+    'BLOSUM62_NUM_' + list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i+1'
+    for i in range(20)
+]
+im1_cols_bin += [
+    'BINSEQREP_' + list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i-1'
+    for i in range(20)
+]
+ip1_cols_bin += [
+    'BINSEQREP_' + list(IUPACData.protein_letters_3to1.keys())[i].upper() + '_i+1'
+    for i in range(20)
+]
 
-# Some other columns
-protein_letters=[code.upper() for code in IUPACData.protein_letters_3to1.keys()]
-sp_feat_cols=['BLOSUM62_NUM_ALA_i-1', 'BLOSUM62_NUM_CYS_i-1', 'BLOSUM62_NUM_ASP_i-1', 'BLOSUM62_NUM_GLU_i-1', 'BLOSUM62_NUM_PHE_i-1', 
-'BLOSUM62_NUM_GLY_i-1', 'BLOSUM62_NUM_HIS_i-1', 'BLOSUM62_NUM_ILE_i-1', 'BLOSUM62_NUM_LYS_i-1', 'BLOSUM62_NUM_LEU_i-1', 'BLOSUM62_NUM_MET_i-1', 
-'BLOSUM62_NUM_ASN_i-1', 'BLOSUM62_NUM_PRO_i-1', 'BLOSUM62_NUM_GLN_i-1', 'BLOSUM62_NUM_ARG_i-1', 'BLOSUM62_NUM_SER_i-1', 'BLOSUM62_NUM_THR_i-1', 
-'BLOSUM62_NUM_VAL_i-1', 'BLOSUM62_NUM_TRP_i-1', 'BLOSUM62_NUM_TYR_i-1', 'PHI_SIN_i-1', 'PHI_COS_i-1', 'PSI_SIN_i-1', 'PSI_COS_i-1', 'CHI1_SIN_i-1',
- 'CHI1_COS_i-1', 'CHI1_EXISTS_i-1', 'CHI2_SIN_i-1', 'CHI2_COS_i-1', 'CHI2_EXISTS_i-1', 'BLOSUM62_NUM_ALA_i', 'BLOSUM62_NUM_CYS_i', 'BLOSUM62_NUM_ASP_i',
- 'BLOSUM62_NUM_GLU_i', 'BLOSUM62_NUM_PHE_i', 'BLOSUM62_NUM_GLY_i', 'BLOSUM62_NUM_HIS_i', 'BLOSUM62_NUM_ILE_i', 'BLOSUM62_NUM_LYS_i', 'BLOSUM62_NUM_LEU_i',
- 'BLOSUM62_NUM_MET_i', 'BLOSUM62_NUM_ASN_i', 'BLOSUM62_NUM_PRO_i', 'BLOSUM62_NUM_GLN_i', 'BLOSUM62_NUM_ARG_i', 'BLOSUM62_NUM_SER_i', 'BLOSUM62_NUM_THR_i',
- 'BLOSUM62_NUM_VAL_i', 'BLOSUM62_NUM_TRP_i', 'BLOSUM62_NUM_TYR_i', 'PHI_SIN_i', 'PHI_COS_i', 'PSI_SIN_i', 'PSI_COS_i', 'CHI1_SIN_i', 'CHI1_COS_i', 
- 'CHI1_EXISTS_i', 'CHI2_SIN_i', 'CHI2_COS_i', 'CHI2_EXISTS_i', 'BLOSUM62_NUM_ALA_i+1', 'BLOSUM62_NUM_CYS_i+1', 'BLOSUM62_NUM_ASP_i+1', 
- 'BLOSUM62_NUM_GLU_i+1', 'BLOSUM62_NUM_PHE_i+1', 'BLOSUM62_NUM_GLY_i+1', 'BLOSUM62_NUM_HIS_i+1', 'BLOSUM62_NUM_ILE_i+1', 'BLOSUM62_NUM_LYS_i+1', 
- 'BLOSUM62_NUM_LEU_i+1', 'BLOSUM62_NUM_MET_i+1', 'BLOSUM62_NUM_ASN_i+1', 'BLOSUM62_NUM_PRO_i+1', 'BLOSUM62_NUM_GLN_i+1', 'BLOSUM62_NUM_ARG_i+1',
-'BLOSUM62_NUM_SER_i+1', 'BLOSUM62_NUM_THR_i+1', 'BLOSUM62_NUM_VAL_i+1', 'BLOSUM62_NUM_TRP_i+1', 'BLOSUM62_NUM_TYR_i+1', 'PHI_SIN_i+1', 'PHI_COS_i+1',
-'PSI_SIN_i+1', 'PSI_COS_i+1', 'CHI1_SIN_i+1', 'CHI1_COS_i+1', 'CHI1_EXISTS_i+1', 'CHI2_SIN_i+1', 'CHI2_COS_i+1', 'CHI2_EXISTS_i+1', 'O__EXISTS_i-1',
-'O_d_HA_i-1', 'O__COS_A_i-1', 'O__COS_H_i-1', 'HN__EXISTS_i', 'HN_d_HA_i', 'HN__COS_A_i', 'HN__COS_H_i', 'Ha__EXISTS_i', 'Ha_d_HA_i', 'Ha__COS_A_i', 
-'Ha__COS_H_i', 'O__EXISTS_i', 'O_d_HA_i', 'O__COS_A_i', 'O__COS_H_i', 'HN__EXISTS_i+1', 'HN_d_HA_i+1', 'HN__COS_A_i+1', 'HN__COS_H_i+1', 'S2_i-1', 'S2_i',
- 'S2_i+1']
-spartap_cols=sp_feat_cols+atom_names+[a+"_RC" for a in atom_names]+["FILE_ID","RESNAME","RES_NUM"]
-col_square=["%s_%s_%s"%(a,b,c) for a in ['PHI','PSI'] for b in ['COS','SIN'] for c in ['i-1','i','i+1']]  
-dropped_cols=["DSSP_%s_%s"%(a,b) for a in ["PHI","PSI"] for b in ['i-1','i','i+1']]+["BMRB_RES_NUM","MATCHED_BMRB","CG","HA2_RING","HA3_RING","RCI_S2","identifier"]
-col_lift=[col for col in sp_feat_cols if "BLOSUM" not in col and "_i-1" not in col and "_i+1" not in col]
-non_numerical_cols=['3_10_HELIX_SS_i',"A_HELIX_SS_i","BEND_SS_i","B_BRIDGE_SS_i","CHI1_EXISTS_i","CHI2_EXISTS_i","HN__EXISTS_i","Ha__EXISTS_i","NONE_SS_i","O__EXISTS_i","PI_HELIX_SS_i","STRAND_SS_i","TURN_SS_i"]+protein_letters
+protein_letters = [code.upper() for code in IUPACData.protein_letters_3to1.keys()]
+sp_feat_cols = [
+    'BLOSUM62_NUM_ALA_i-1', 'BLOSUM62_NUM_CYS_i-1', 'BLOSUM62_NUM_ASP_i-1',
+    'BLOSUM62_NUM_GLU_i-1', 'BLOSUM62_NUM_PHE_i-1', 'BLOSUM62_NUM_GLY_i-1',
+    'BLOSUM62_NUM_HIS_i-1', 'BLOSUM62_NUM_ILE_i-1', 'BLOSUM62_NUM_LYS_i-1',
+    'BLOSUM62_NUM_LEU_i-1', 'BLOSUM62_NUM_MET_i-1', 'BLOSUM62_NUM_ASN_i-1',
+    'BLOSUM62_NUM_PRO_i-1', 'BLOSUM62_NUM_GLN_i-1', 'BLOSUM62_NUM_ARG_i-1',
+    'BLOSUM62_NUM_SER_i-1', 'BLOSUM62_NUM_THR_i-1', 'BLOSUM62_NUM_VAL_i-1',
+    'BLOSUM62_NUM_TRP_i-1', 'BLOSUM62_NUM_TYR_i-1',
+    'PHI_SIN_i-1', 'PHI_COS_i-1', 'PSI_SIN_i-1', 'PSI_COS_i-1',
+    'CHI1_SIN_i-1', 'CHI1_COS_i-1', 'CHI1_EXISTS_i-1',
+    'CHI2_SIN_i-1', 'CHI2_COS_i-1', 'CHI2_EXISTS_i-1',
+    'BLOSUM62_NUM_ALA_i', 'BLOSUM62_NUM_CYS_i', 'BLOSUM62_NUM_ASP_i',
+    'BLOSUM62_NUM_GLU_i', 'BLOSUM62_NUM_PHE_i', 'BLOSUM62_NUM_GLY_i',
+    'BLOSUM62_NUM_HIS_i', 'BLOSUM62_NUM_ILE_i', 'BLOSUM62_NUM_LYS_i',
+    'BLOSUM62_NUM_LEU_i', 'BLOSUM62_NUM_MET_i', 'BLOSUM62_NUM_ASN_i',
+    'BLOSUM62_NUM_PRO_i', 'BLOSUM62_NUM_GLN_i', 'BLOSUM62_NUM_ARG_i',
+    'BLOSUM62_NUM_SER_i', 'BLOSUM62_NUM_THR_i', 'BLOSUM62_NUM_VAL_i',
+    'BLOSUM62_NUM_TRP_i', 'BLOSUM62_NUM_TYR_i',
+    'PHI_SIN_i', 'PHI_COS_i', 'PSI_SIN_i', 'PSI_COS_i',
+    'CHI1_SIN_i', 'CHI1_COS_i', 'CHI1_EXISTS_i',
+    'CHI2_SIN_i', 'CHI2_COS_i', 'CHI2_EXISTS_i',
+    'BLOSUM62_NUM_ALA_i+1', 'BLOSUM62_NUM_CYS_i+1', 'BLOSUM62_NUM_ASP_i+1',
+    'BLOSUM62_NUM_GLU_i+1', 'BLOSUM62_NUM_PHE_i+1', 'BLOSUM62_NUM_GLY_i+1',
+    'BLOSUM62_NUM_HIS_i+1', 'BLOSUM62_NUM_ILE_i+1', 'BLOSUM62_NUM_LYS_i+1',
+    'BLOSUM62_NUM_LEU_i+1', 'BLOSUM62_NUM_MET_i+1', 'BLOSUM62_NUM_ASN_i+1',
+    'BLOSUM62_NUM_PRO_i+1', 'BLOSUM62_NUM_GLN_i+1', 'BLOSUM62_NUM_ARG_i+1',
+    'BLOSUM62_NUM_SER_i+1', 'BLOSUM62_NUM_THR_i+1', 'BLOSUM62_NUM_VAL_i+1',
+    'BLOSUM62_NUM_TRP_i+1', 'BLOSUM62_NUM_TYR_i+1',
+    'PHI_SIN_i+1', 'PHI_COS_i+1', 'PSI_SIN_i+1', 'PSI_COS_i+1',
+    'CHI1_SIN_i+1', 'CHI1_COS_i+1', 'CHI1_EXISTS_i+1',
+    'CHI2_SIN_i+1', 'CHI2_COS_i+1', 'CHI2_EXISTS_i+1',
+    'O__EXISTS_i-1', 'O_d_HA_i-1', 'O__COS_A_i-1', 'O__COS_H_i-1',
+    'HN__EXISTS_i', 'HN_d_HA_i', 'HN__COS_A_i', 'HN__COS_H_i',
+    'Ha__EXISTS_i', 'Ha_d_HA_i', 'Ha__COS_A_i', 'Ha__COS_H_i',
+    'O__EXISTS_i', 'O_d_HA_i', 'O__COS_A_i', 'O__COS_H_i',
+    'HN__EXISTS_i+1', 'HN_d_HA_i+1', 'HN__COS_A_i+1', 'HN__COS_H_i+1',
+    'S2_i-1', 'S2_i', 'S2_i+1',
+]
+spartap_cols = sp_feat_cols + atom_names + [a + "_RC" for a in atom_names] + ["FILE_ID", "RESNAME", "RES_NUM"]
+col_square = [f"{a}_{b}_{c}" for a in ['PHI', 'PSI'] for b in ['COS', 'SIN'] for c in ['i-1', 'i', 'i+1']]
+dropped_cols = [f"DSSP_{a}_{b}" for a in ["PHI", "PSI"] for b in ['i-1', 'i', 'i+1']] + [
+    "BMRB_RES_NUM", "MATCHED_BMRB", "CG", "HA2_RING", "HA3_RING", "RCI_S2", "identifier"
+]
+col_lift = [col for col in sp_feat_cols if "BLOSUM" not in col and "_i-1" not in col and "_i+1" not in col]
+non_numerical_cols = [
+    '3_10_HELIX_SS_i', "A_HELIX_SS_i", "BEND_SS_i", "B_BRIDGE_SS_i",
+    "CHI1_EXISTS_i", "CHI2_EXISTS_i", "HN__EXISTS_i", "Ha__EXISTS_i",
+    "NONE_SS_i", "O__EXISTS_i", "PI_HELIX_SS_i", "STRAND_SS_i", "TURN_SS_i",
+] + protein_letters
 
-# These are the names of the columns that are not in Sparta+ but are in the un-augmented features from our extraction
 cols_notinsp = dssp_cols + hse_cols + ext_seq_cols
 
 
-# Now some stuff to read in data
+# ── Core feature functions ────────────────────────────────────────────────────
 
-# Read in ShiftX2 data
-# Athena -- 
-try:
-    train_sx2 = pd.read_csv('/home/bennett/Documents/DataSets/bmrb_clean/clean_rings/train_shiftx2_clean_rings.csv')
-    test_sx2 = pd.read_csv('/home/bennett/Documents/DataSets/bmrb_clean/clean_rings/test_shiftx2_clean_rings.csv')
-except FileNotFoundError:
-    pass
-# Hermes
-try:
-    train_sx2 = pd.read_csv('/home/kochise/data/shiftx2/clean_rings/train_shiftx2_clean_rings.csv')
-    test_sx2 = pd.read_csv('/home/kochise/data/shiftx2/clean_rings/test_shiftx2_clean_rings.csv')
-except FileNotFoundError:
-    pass
-# Office
-try:
-#    train_sx2 = pd.read_csv('/Users/kcbennett/Documents/data/ShiftX2/bmrb_clean/train_shiftx2_clean_rings.csv')
-#    test_sx2 = pd.read_csv('/Users/kcbennett/Documents/data/ShiftX2/bmrb_clean/test_shiftx2_clean_rings.csv')
-    shiftx2_train = pd.read_csv('/Users/kcbennett/Documents/data/ShiftX2/sx2train_dssp.csv')
-    shiftx2_test = pd.read_csv('/Users/kcbennett/Documents/data/ShiftX2/sx2test_dssp.csv')
-except FileNotFoundError:
-    pass
-
-# Need to write a function to get targets as differences between raw shifts and the
-# random coil and ring current values
-def diff_targets(data, rings=False, coils=True, drop_cols=True):
-    '''Function that replaces the shifts column with the difference between the raw
-    shifts and the values in the columns given
-    
-    data = Feature and target data (Pandas DataFrame)
-    rings = Subtract ring current columns from shift columns (Bool)
-    coils = Subtract random coil columns from shift columns (Bool)
-    drop_cols = Whether or not drop corresponding columns after obtaining the target difference
-    '''
+def diff_targets(data: pd.DataFrame, rings: bool = False, coils: bool = True, drop_cols: bool = True) -> pd.DataFrame:
     df = data.copy()
     if rings:
         df[atom_names] = df[atom_names].values - df[ring_cols].fillna(0).values
         if drop_cols:
             df.drop(ring_cols, axis=1, inplace=True)
-    
     if coils:
         df[atom_names] = df[atom_names].values - df[rcoil_cols].values
         if drop_cols:
             df.drop(rcoil_cols, axis=1, inplace=True)
-    
     return df
 
-# Define feature augmentation functions
 
-def feat_pwr(data, columns, pwrs):
-    '''Function to augment the feature set by adding new columns corresponding to given powers of selected features.
-    
-    args:
-        data = Contains the data to be augmented (Pandas DataFrame)
-        columns = List of columns to be used for the feature augmentation (List of Str)
-        pwrs = List of exponents to use for feature augmentation (List of Float)
-    
-    returns:
-        dat - Augmented data (Pandas DataFrame)
-    '''
+def feat_pwr(data: pd.DataFrame, columns: list, pwrs: list) -> pd.DataFrame:
     dat = data.copy()
     for col in columns:
         for power in pwrs:
-            new_col_name = col + '^' + str(power)
+            new_col_name = f"{col}^{power}"
             if power < 0:
                 dat[new_col_name] = 0
-                dat.loc[dat[col] > 0, new_col_name] = dat.loc[dat[col] > 0, col]**power
+                dat.loc[dat[col] > 0, new_col_name] = dat.loc[dat[col] > 0, col] ** power
             else:
-                dat[new_col_name] = dat[col]**power
+                dat[new_col_name] = dat[col] ** power
     return dat
 
-def Add_res_spec_feats(dataset,include_onehot=True):
-    '''
-    Adding residue specific features into the dataset (only for current residue), including one-hot representation of the residue,
-    and the hydrophobicity of the residue
-    '''
+
+def featsq(data: pd.DataFrame, columns: list) -> pd.DataFrame:
+    """Square the given columns — alias for feat_pwr with power=2."""
+    return feat_pwr(data, columns, [2])
+
+
+def Add_res_spec_feats(dataset: pd.DataFrame, include_onehot: bool = True) -> None:
     if include_onehot:
         for code in protein_letters:
-            dataset[code]=[int(res==code) for res in dataset['RESNAME']]
-    dataset["HYDROPHOBICITY"]=[hydrophobic_dict[res] for res in dataset['RESNAME']]
-
-# Feature space lifting
-def Lift_Space(dataset,participating_cols,increased_dim,w,b):
-    if w is None:
-        w = np.random.normal(0, 0.1, (len(participating_cols), increased_dim))
-        b = np.random.uniform(0, 2*np.pi, increased_dim)
-    lifted_dat_mat=np.cos(dataset[participating_cols].values.dot(w)+b)
-    for n in range(increased_dim):
-        dataset["Lifted_%d"%n]=lifted_dat_mat[:,n]
-
-def encode_onehot(sequence_feat):
-    '''
-    Encode the sequence features into one-hot representation.
-    sequence_feat: The sequence features that has length of total number of examples (N) and each element
-     is a list of residue names with length (L)  (List/DataFrame)
-    Returns a three-dimensional numpy array that has shape (N,L,20) 
-    '''
-    RES_CODES=sorted([code.upper() for code in IUPACData.protein_letters_3to1.keys()])
-    RES_CODES_DICT={code:idx for idx,code in enumerate(RES_CODES)}
-    onehot=np.zeros((len(sequence_feat),len(sequence_feat[0]),20))
-    for idx_seq,seq in enumerate(sequence_feat):
-        for idx_res,amino_acid in enumerate(seq):
-            if amino_acid in RES_CODES:
-                onehot[idx_seq][idx_res][RES_CODES_DICT[amino_acid]]=1
-    return onehot 
-
-# Adding classification results into features
-def Implant_classification(dataset,model,half_window=20):
-    print("Predicting using classification model...")
-    input_cols=["RESNAME_i-%d"%n for n in range(half_window,0,-1)]+["RESNAME"]+["RESNAME_i+%d"%n for n in range(1,half_window+1)]
-    input_classification=encode_onehot(dataset[input_cols].values)
-    pred=model.predict(input_classification,verbose=1)
-    class_names=["CLASS_"+str(i+1) for i in range(pred[0].shape[1])]
-    for col in class_names:
-        dataset[col]=0
-    dataset[class_names]=pred[0]
-
-def filter_outlier(data,atom,outlier_path="./"):
-    '''
-    Function to filter outliers from training and validation data based on PDBID and RESNUM. The outliers were selected out by 10 fold cross validation with sparta+ network with out-of-std predictions
-    '''
-    data["identifier"]=data["FILE_ID"].astype(str)+data["RES_NUM"].map(str)
-    outlier=pd.read_csv(outlier_path+"filtered_"+atom+".csv")
-    for i in range(len(outlier)):
-        identifier=outlier.iloc[i]["PDB"]+str(outlier.iloc[i]["RESNUM"])
-        resname=outlier.iloc[i]["RESNAME"]
-        filtered=data[data["identifier"]==identifier]
-        assert len(filtered)<=1
-        if len(filtered)==1:
-            # this item need to be filtered
-            idx=filtered.iloc[0].name
-            assert data.loc[idx,"RESNAME"]==resname
-            data.loc[idx,atom]=np.nan
-        if((i+1)%100==0):
-            print("%d/%d"%(i+1,len(outlier)),end="\r")
-    data.drop("identifier",axis=1,inplace=True)
+            dataset[code] = [int(res == code) for res in dataset['RESNAME']]
+    dataset["HYDROPHOBICITY"] = [hydrophobic_dict[res] for res in dataset['RESNAME']]
 
 
-# Define purifier functions
-def dihedral_purifier(data, tol=0.001, drop_cols=True, set_nans=True):
-    '''Function to purify given data based on eliminating those residues for which Biopython and DSSP disagree on dihedral angles by more than tol in Cos value for Phi_i.
-    
-    args:
-        data - Data to be purified (Pandas DataFrame)
-        tol - Tolerance for dihedral angle Cos values (Float)
-        drop_cols - Drop columns associated with DSSP PHI/PSI angles (Bool)
-        set_nans - Replace all shifts with NaN in filtered rows rather than removing said rows (Bool)
-    
-    returns:
-        dat - Data with examples removed if Biopython and DSSP disagree by too much (Pandas DataFrame)
-    '''
+def ha23ambigfix(data: pd.DataFrame, mode: int = 0) -> pd.DataFrame:
     dat = data.copy()
-    phipsidev = np.abs(dat['PHI_COS_i'] - np.cos(np.pi / 180 * dat['DSSP_PHI_i'].astype(np.float64).values))
-    good_idxs = ((dat['PHI_COS_i'] == 0) & (dat['PHI_SIN_i'] == 0)) | (phipsidev == 1) | (phipsidev <= 0.001)
-    if set_nans:
-        dat.loc[~good_idxs, atom_names] = np.nan
-    else:
-        dat = dat.loc[good_idxs]
-    if drop_cols:
-        dat = dat.drop(['DSSP_' + i + j for i in ['PHI', 'PSI'] for j in ['_i-1', '_i', '_i+1']], axis=1)
-    return dat
-
-def dssp_purifier(data, set_nans=True):
-    '''Function to remove examples where DSSP fails to classify the secondary structure.
-    
-    args:
-        data - Given data to be filtered (Pandas DataFrame)
-        set_nans - Replace all shifts with NaN in filtered rows rather than removing said rows (Bool)
-    
-    returns:
-        dat - Filtered data (Pandas DataFrame)
-    '''
-    dat = data.copy()
-    bad_idxs = dat[(dat[dssp_ssi_cols[0]]==0) & (dat[dssp_ssi_cols[1]]==0) & (dat[dssp_ssi_cols[2]]==0) & (dat[dssp_ssi_cols[3]]==0) & (dat[dssp_ssi_cols[4]]==0) & (dat[dssp_ssi_cols[5]]==0) & (dat[dssp_ssi_cols[6]]==0) & (dat[dssp_ssi_cols[7]]==0)].index
-    if set_nans:
-        dat.loc[bad_idxs, atom_names] = np.nan
-    else:
-        dat = dat.drop(bad_idxs) 
-    return dat
-
-def medianize(data, cols, medians=None):
-    '''Function to replace zeros by medians for specified columnns.
-    
-    args:
-        data - Data containing columns with zeros to be replaced (Pandas DataFrame)
-        cols - Names of columns with zeros that are to be replaced (List)
-        medians - Explicit list of medians to use for replacement in testing data (List)
-    
-    returns:
-        meds - Medians used for replacement (List)
-        dat - Data with zeros replaced by medians (Pandas DataFrame)
-    '''
-    dat = data.copy()
-    if medians is not None:
-        meds = medians
-    else:
-        meds = [dat.loc[dat[col] != 0, col].median() for col in cols]
-    med_dict = dict(zip(cols, meds))
-    for col in cols:
-        dat.loc[(dat[col] == 0), col] = med_dict[col]
-    return meds, dat
-
-def rc_fix(data,use_null=False):
-    '''
-    Function to replace zeroes in random coils into some more reasonable values
-    use_null - If true, set null to those values that have unknown random coil values
-    '''
-    if use_null:
-        checklist={"N":["PRO",np.nan],"H":["PRO",np.nan],"CB":["GLY",np.nan]}
-    else:
-        checklist={"N":["PRO",119.5],"H":["PRO",8.23],"CB":["GLY",36.8]}
-    for atom in atom_names:
-        zero_indices=data[data["RCOIL_"+atom]==0].index
-        for idx in zero_indices:
-            assert data.loc[idx,"RESNAME"]==checklist[atom][0]
-            data.loc[idx,"RCOIL_"+atom]=checklist[atom][1]
-
-def ha23ambigfix(data, mode=0):
-    '''Function to use the HA2/HA3 ring current calculations in a way that resolves ambiguity.
-    
-    args:
-        data - Data to fix (Pandas DataFrame)
-        mode - Method of resolving ambiguity, 0 -> use average, 1 -> use HA2, 2 -> use HA3 (Int)
-    
-    returns:
-        dat - Data with ring current ambiguity resolved and extra columns dropped
-    '''
-    dat = data.copy()
-    idx_ha = [i for i in list(dat[dat['HA2_RING'].notnull()].index)]
-    if mode==0:
+    idx_ha = dat[dat['HA2_RING'].notnull()].index.tolist()
+    if mode == 0:
         for i in idx_ha:
             dat.loc[i, 'HA_RC'] = (dat.loc[i, 'HA2_RING'] + dat.loc[i, 'HA3_RING']) / 2
-    elif mode==1:
+    elif mode == 1:
         for i in idx_ha:
             dat.loc[i, 'HA_RC'] = dat.loc[i, 'HA2_RING']
-    elif mode==2:
+    elif mode == 2:
         for i in idx_ha:
             dat.loc[i, 'HA_RC'] = dat.loc[i, 'HA3_RING']
     dat = dat.drop(['HA2_RING', 'HA3_RING'], axis=1)
     return dat
 
-def check_nan_shifts(data, thr, ends=False):
-    '''Function to check the number of NaN shifts in each row and, for each residue with fewer than thr non-NaN shifts, sets all shifts for that residue as well as neighbors to be NaN so that those residues will be excluded from training/evaluation
-    
-    args:
-        data - Data to be cleansed (Pandas DataFrame)
-        thr - Number of non-NaN shifts required for a residue and neighbors to survive (Int)
-        ends - Set shifts of atoms on first and last residue of each chain to be NaN as well (Bool)
-    
-    returns:
-        dat - Cleaned data (Pandas DataFrame)
-    '''
+
+def dihedral_purifier(data: pd.DataFrame, tol: float = 0.001, drop_cols: bool = True, set_nans: bool = True) -> pd.DataFrame:
+    dat = data.copy()
+    phipsidev = np.abs(
+        dat['PHI_COS_i'] - np.cos(np.pi / 180 * dat['DSSP_PHI_i'].astype(np.float64).values)
+    )
+    good_idxs = (
+        ((dat['PHI_COS_i'] == 0) & (dat['PHI_SIN_i'] == 0))
+        | (phipsidev == 1)
+        | (phipsidev <= tol)
+    )
+    if set_nans:
+        dat.loc[~good_idxs, atom_names] = np.nan
+    else:
+        dat = dat.loc[good_idxs]
+    if drop_cols:
+        dat = dat.drop(
+            ['DSSP_' + i + j for i in ['PHI', 'PSI'] for j in ['_i-1', '_i', '_i+1']],
+            axis=1,
+        )
+    return dat
+
+
+def dssp_purifier(data: pd.DataFrame, set_nans: bool = True) -> pd.DataFrame:
+    dat = data.copy()
+    bad_idxs = dat[
+        (dat[dssp_ssi_cols[0]] == 0) & (dat[dssp_ssi_cols[1]] == 0) &
+        (dat[dssp_ssi_cols[2]] == 0) & (dat[dssp_ssi_cols[3]] == 0) &
+        (dat[dssp_ssi_cols[4]] == 0) & (dat[dssp_ssi_cols[5]] == 0) &
+        (dat[dssp_ssi_cols[6]] == 0) & (dat[dssp_ssi_cols[7]] == 0)
+    ].index
+    if set_nans:
+        dat.loc[bad_idxs, atom_names] = np.nan
+    else:
+        dat = dat.drop(bad_idxs)
+    return dat
+
+
+def medianize(data: pd.DataFrame, cols: list, medians: Optional[list] = None):
+    dat = data.copy()
+    meds = medians if medians is not None else [dat.loc[dat[col] != 0, col].median() for col in cols]
+    med_dict = dict(zip(cols, meds))
+    for col in cols:
+        dat.loc[dat[col] == 0, col] = med_dict[col]
+    return meds, dat
+
+
+def rc_fix(data: pd.DataFrame, use_null: bool = False) -> None:
+    if use_null:
+        checklist = {"N": ["PRO", np.nan], "H": ["PRO", np.nan], "CB": ["GLY", np.nan]}
+    else:
+        checklist = {"N": ["PRO", 119.5], "H": ["PRO", 8.23], "CB": ["GLY", 36.8]}
+    for atom in atom_names:
+        zero_indices = data[data["RCOIL_" + atom] == 0].index
+        for idx in zero_indices:
+            assert data.loc[idx, "RESNAME"] == checklist[atom][0]
+            data.loc[idx, "RCOIL_" + atom] = checklist[atom][1]
+
+
+def check_nan_shifts(data: pd.DataFrame, thr: int, ends: bool = False) -> pd.DataFrame:
     dat = data.copy()
     for idx in range(len(dat)):
         snums = dat.loc[idx, atom_names].count()
@@ -449,13 +332,13 @@ def check_nan_shifts(data, thr, ends=False):
                 chain_m1 = dat.loc[idx - 1, 'CHAIN']
                 if (file == file_m1) and (chain == chain_m1):
                     dat.loc[idx - 1, atom_names] = np.nan
-            if idx < (len(dat) -1):
+            if idx < len(dat) - 1:
                 file_p1 = dat.loc[idx + 1, 'PDB_FILE_NAME']
                 chain_p1 = dat.loc[idx + 1, 'CHAIN']
                 if (file == file_m1) and (chain == chain_m1):
                     dat.loc[idx + 1, atom_names] = np.nan
         if ends:
-            if (idx == 0) or (idx == len(dat) -1):
+            if idx == 0 or idx == len(dat) - 1:
                 dat.loc[idx, atom_names] = np.nan
             elif (file != file_m1) or (chain == chain_m1):
                 dat.loc[idx, atom_names] = np.nan
@@ -465,56 +348,72 @@ def check_nan_shifts(data, thr, ends=False):
                 dat.loc[idx + 1, atom_names] = np.nan
     return dat
 
-def raw_dprep(data, ha23mode=0, power_dict={2.0 : square_cols, -1.0 : hbondd_cols, -2.0 : hbondd_cols, -3.0 : hbondd_cols}, diff_rings=False):
-    '''Function to prepare freshly-extracted data.
-    
-    args:
-        data - Data to be prepared (Pandas DataFrame)
-        ha23mode - Method of resolving ambiguity for HA2/3; see ha23ambigfix function (Int, 0 or 1)
-        power_dict - Dictionary where keys are powers and corresponding values are lists of the column names.  These columns are raised to the corresonding power and the result is stored as new columns, augmenting the feature set (Dict)
-        diff_rings - Difference the ring current contributions from the shifts.  Only use this if not doing kfold with the result since it requires that we pre-medianize the ring current contributions to eliminate NaN values and in principle this should be done at each fold separately (Bool)
-    
-    returns:
-        dat - Cleaned data ready to be inserted into a kfold_crossval or model-generating function
-    
-    '''
-    dat = data.rename(index=str, columns=sx2_rename_map)
-    dat.index = pd.RangeIndex(start=0, stop=len(dat), step=1)
+
+def filter_outlier(data: pd.DataFrame, atom: str, outlier_path: str = "./") -> None:
+    data["identifier"] = data["FILE_ID"].astype(str) + data["RES_NUM"].map(str)
+    outlier = pd.read_csv(f"{outlier_path}filtered_{atom}.csv")
+    for i in range(len(outlier)):
+        identifier = outlier.iloc[i]["PDB"] + str(outlier.iloc[i]["RESNUM"])
+        resname = outlier.iloc[i]["RESNAME"]
+        filtered = data[data["identifier"] == identifier]
+        assert len(filtered) <= 1
+        if len(filtered) == 1:
+            idx = filtered.iloc[0].name
+            assert data.loc[idx, "RESNAME"] == resname
+            data.loc[idx, atom] = np.nan
+        if (i + 1) % 100 == 0:
+            print(f"{i + 1}/{len(outlier)}", end="\r")
+    data.drop("identifier", axis=1, inplace=True)
+
+
+def raw_dprep(
+    data: pd.DataFrame,
+    ha23mode: int = 0,
+    power_dict: Optional[dict] = None,
+    diff_rings: bool = False,
+) -> pd.DataFrame:
+    if power_dict is None:
+        power_dict = {2.0: square_cols, -1.0: hbondd_cols, -2.0: hbondd_cols, -3.0: hbondd_cols}
+    dat = data.rename(columns=sx2_rename_map)
+    dat.index = pd.RangeIndex(len(dat))
     dat = ha23ambigfix(dat, mode=ha23mode)
-    try: # If DSSP columns are available, use them to filter a few bad residues based on the criteria in dihedral_purifier and dssp_purifier
+    try:
         dat = dihedral_purifier(dat, drop_cols=True)
         dat = dssp_purifier(dat)
     except KeyError:
         pass
-    for pwr in power_dict.keys(): # Augment the feature set with a few non-linear transformations
-        dat = feat_pwr(dat, power_dict[pwr], [pwr])
-    # It is assumed that random coil columns are contained in the data
+    for pwr, cols in power_dict.items():
+        dat = feat_pwr(dat, cols, [pwr])
     if diff_rings:
         for col in ring_cols:
-            null_idxs = [int(i) for i in list(dat[dat[col].isnull()].index)]
+            null_idxs = dat[dat[col].isnull()].index.tolist()
             dat.loc[null_idxs, col] = dat[col].median()
         dat = diff_targets(dat, rings=True, coils=True)
     else:
         dat = diff_targets(dat, rings=False, coils=True)
-    dat.index = pd.RangeIndex(start=0, stop=len(dat), step=1)
+    dat.index = pd.RangeIndex(len(dat))
     return dat
 
-def sx2_dprep(train_data, test_data, ha23mode=0, med_cols=angle_cols+hbondd_cols, add_squares=square_cols, med_rings=False, diff_rings=False, medians=True, normalize=False):
-    '''Function to completely prepare test and train data from shiftx2 extraction.
-    
-    args:
-        train_data = Training data to prepare (Pandas DataFrame)
-        test_data = Test data to prepare (Pandas DataFrame)
-        ha23mode = Mode for resolving HA2/HA3 ring current ambiguity (0, 1, or 2 -- See ha23ambigfix function)
-        
-    returns:
-        train_dat - Prepared training data (Pandas DataFrame)
-        test_dat - Prepared test data (Pandas DataFrame)
-    '''
-    train_dat = train_data.rename(index=str, columns=sx2_rename_map)
-    test_dat = test_data.rename(index=str, columns=sx2_rename_map)
-    train_dat.index = pd.RangeIndex(start=0, stop=len(train_dat), step=1)
-    test_dat.index = pd.RangeIndex(start=0, stop=len(test_dat), step=1)
+
+def sx2_dprep(
+    train_data: pd.DataFrame,
+    test_data: pd.DataFrame,
+    ha23mode: int = 0,
+    med_cols: Optional[list] = None,
+    add_squares: Optional[list] = None,
+    med_rings: bool = False,
+    diff_rings: bool = False,
+    medians: bool = True,
+    normalize: bool = False,
+):
+    if med_cols is None:
+        med_cols = angle_cols + hbondd_cols
+    if add_squares is None:
+        add_squares = square_cols
+    train_dat = train_data.rename(columns=sx2_rename_map)
+    test_dat = test_data.rename(columns=sx2_rename_map)
+    train_dat.index = pd.RangeIndex(len(train_dat))
+    test_dat.index = pd.RangeIndex(len(test_dat))
     train_dat = dihedral_purifier(train_dat)
     test_dat = dihedral_purifier(test_dat)
     train_dat = dssp_purifier(train_dat)
@@ -524,34 +423,34 @@ def sx2_dprep(train_data, test_data, ha23mode=0, med_cols=angle_cols+hbondd_cols
         _, test_dat = medianize(test_dat, med_cols, train_medians)
     train_dat = ha23ambigfix(train_dat, mode=ha23mode)
     test_dat = ha23ambigfix(test_dat, mode=ha23mode)
-    # Fill in ring columns with medians
     if med_rings:
         for col in ring_cols:
-            null_idxs_train = [int(i) for i in list(train_dat[train_dat[col].isnull()].index)]
-            null_idxs_test = [int(i) for i in list(test_dat[test_dat[col].isnull()].index)]
-            train_dat.loc[null_idxs_train, col] = train_dat[col].median()
-            test_dat.loc[null_idxs_test, col] = train_dat[col].median()
-    # Add square columns
+            null_train = train_dat[train_dat[col].isnull()].index.tolist()
+            null_test = test_dat[test_dat[col].isnull()].index.tolist()
+            train_dat.loc[null_train, col] = train_dat[col].median()
+            test_dat.loc[null_test, col] = train_dat[col].median()
     if add_squares is not None:
         train_dat = featsq(train_dat, add_squares)
         test_dat = featsq(test_dat, add_squares)
-    
-    # Difference the raw shifts with random coil (and maybe ring current) contributions 
     train_dat = diff_targets(train_dat, rings=diff_rings, coils=True)
     test_dat = diff_targets(test_dat, rings=diff_rings, coils=True)
-    # Normalize all columns
-    if normalize:
-        sx2_means, sx2_stds, train_dat = whitener(struc_cols + col_blosum + ring_cols + hse_cols + dssp_norm_cols, train_dat)
-        _, _, test_dat = whitener(struc_cols + col_blosum + ring_cols + hse_cols + dssp_norm_cols, test_dat, means=sx2_means, stds=sx2_stds, test_data=True)
-    
-    train_dat.index = pd.RangeIndex(start=0, stop=len(train_dat), step=1)
-    test_dat.index = pd.RangeIndex(start=0, stop=len(test_dat), step=1)
+    train_dat.index = pd.RangeIndex(len(train_dat))
+    test_dat.index = pd.RangeIndex(len(test_dat))
     return train_dat, test_dat
 
-def sp_dprep(data, ha23mode=0, spfeats_only=False, med_rings=True, add_squares=square_cols, diff_rings=False):
-    '''Function to prepare sparta+ data.'''
-    dat = data.rename(index=str, columns=sx2_rename_map)
-    dat.index = pd.RangeIndex(start=0, stop=len(dat), step=1)
+
+def sp_dprep(
+    data: pd.DataFrame,
+    ha23mode: int = 0,
+    spfeats_only: bool = False,
+    med_rings: bool = True,
+    add_squares: Optional[list] = None,
+    diff_rings: bool = False,
+) -> pd.DataFrame:
+    if add_squares is None:
+        add_squares = square_cols
+    dat = data.rename(columns=sx2_rename_map)
+    dat.index = pd.RangeIndex(len(dat))
     dat = dihedral_purifier(dat, drop_cols=not spfeats_only)
     dat = dssp_purifier(dat)
     if spfeats_only:
@@ -561,65 +460,24 @@ def sp_dprep(data, ha23mode=0, spfeats_only=False, med_rings=True, add_squares=s
     dat = ha23ambigfix(dat, mode=ha23mode)
     if med_rings:
         for col in ring_cols:
-            null_idxs = [int(i) for i in list(dat[dat[col].isnull()].index)]
+            null_idxs = dat[dat[col].isnull()].index.tolist()
             dat.loc[null_idxs, col] = dat[col].median()
     dat = diff_targets(dat, rings=diff_rings, coils=True)
-    dat.index = pd.RangeIndex(start=0, stop=len(dat), step=1)
+    dat.index = pd.RangeIndex(len(dat))
     return dat
 
-def hbond_purifier(data, ang_tol=None, drop_phi=False):
-    '''Function to filter data by H-bond angles or to drop Phi angles.
-    
-    args:
-        data - Data to be filtered (Pandas DataFrame)
-        ang_tol - Tolerance for cosine angle filtration about 180 degrees (None or Float)
-        drop_phi - Whether or not to drop the Phi angles (Bool)
-    
-    returns:
-        dat - Filtered data (Pandas DataFrame)'''
+
+def hbond_purifier(data: pd.DataFrame, ang_tol: Optional[float] = None, drop_phi: bool = False) -> pd.DataFrame:
     dat = data.copy()
     if ang_tol is not None:
-        cos_tol = np.cos((180 - ang_tol) * np.pi/180)
-        hyd_angs = [i + '__COS_H_' + j for i in ['HN', 'Ha', 'O'] for j in ['i-1', 'i', 'i+1']]
+        cos_tol = np.cos((180 - ang_tol) * np.pi / 180)
+        hyd_angs = [f"{i}__COS_H_{j}" for i in ['HN', 'Ha', 'O'] for j in ['i-1', 'i', 'i+1']]
         for col in hyd_angs:
             if col in dat.columns:
                 dat = dat[(dat[col] < cos_tol) | (dat[col] == 0)]
-    
     if drop_phi:
-        phi_angs = [i + '__COS_A_' + j for i in ['HN', 'Ha', 'O'] for j in ['i-1', 'i', 'i+1']]
+        phi_angs = [f"{i}__COS_A_{j}" for i in ['HN', 'Ha', 'O'] for j in ['i-1', 'i', 'i+1']]
         for col in phi_angs:
             if col in dat.columns:
                 dat = dat.drop(col, axis=1)
-    
     return dat
-                
-
-# These few lines are to check chi angles existence for those residues with alt chi definitions
-def get_chis(data, resname):
-    #resname_dict = {'ASN' : [-2, -3, 1, 0, -3], 'HIS' : [-2, -3, 1, 0, -1], 'TRP' : [-3, -2, -4, -3, 1], 'ASP' : [-2, -3, 6, 2, -3], 'LEU' : [-1, -1, -4, -3, 0], 'PHE' : [-2, -2, -3, -3, 6], 'TYR' : [-2, -2, -3, -2, 3], 'VAL' : [0, -1, -3, -2, -1], 'ILE' : [-1, -1, -3, -3, 0]}
-    blos = resname_blos_dict[resname]
-    if resname == 'VAL':
-        chi_name = 'CHI1_EXISTS_i'
-    else:
-        chi_name = 'CHI2_EXISTS_i'
-    dat = data[(data['BLOSUM62_NUM_ALA_i'] == blos[0]) & (data['BLOSUM62_NUM_CYS_i'] == blos[1]) & (data['BLOSUM62_NUM_ASP_i'] == blos[2]) & (data['BLOSUM62_NUM_GLU_i'] == blos[3]) & (data['BLOSUM62_NUM_PHE_i'] == blos[4])]
-    return dat[chi_name]
-        
-def chi2_exist_nums(data, resname):
-    '''returns total number of residues with given resname as well as number of these residues for which chi2 does not exist'''
-    chis = get_chis(data, resname)
-    nres = len(chis)
-    nchis = len(chis[chis < 9])
-    return (nres, nchis)
-    
-
-
-bestH_fckwargs = {'activ' : 'prelu', 'lrate' : 0.001, 'mom' : [0.9, 0.999], 'dec' : 1*10**-6, 'epochs' : 500, 'min_epochs' : 50, 'opt_type' : 'adam', 'do' : 0.4, 'reg' : 0*10**-5, 
-                  'reg_type' : 'L2', 'tol' : 4, 'early_stop' : None, 'bnorm' : True, 'nest' : True, 'lsuv' : True, 'clip_norm' : 0.0, 'clip_val' : 0.0, 'reject_outliers' : None, 
-                  'opt_override' : True, 'noise' : None, 'noise_type': 'angle', 'noise_dist' : 'uniform', 'batch_size' : 64, 'lsuv_batch' : 2048}
-
-H_fckwargs = {'activ' : 'tanh', 'lrate' : 0.0001, 'mom' : [0.9, 0.999], 'dec' : 1*10**-6, 'epochs' : 450, 'min_epochs' : 50, 'opt_type' : 'sgd', 'do' : 0.0, 'reg' : 1*10**-6, 
-              'reg_type' : 'L2', 'tol' : 3, 'pretrain' : 'PQ', 'bnorm' : False, 'nest' : True, 'lsuv' : False, 'clip_norm' : 0.0, 'clip_val' : 0.0, 'reject_outliers' : None,
-              'opt_override' : False, 'noise' : None, 'noise_type': 'percent', 'noise_dist' : 'normal', 'batch_size' : 64, 'lsuv_batch' : 2048}
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.19
-pandas==1.1
-scikit-learn==0.22
-biopython==1.74
-joblib==0.17
-matplotlib==3.3
+numpy>=1.24
+pandas>=2.0
+scikit-learn>=1.3
+biopython>=1.81
+joblib>=1.3
+matplotlib>=3.7

--- a/save_pdb.py
+++ b/save_pdb.py
@@ -1,29 +1,33 @@
-# Self-defined function for writing a PDB file from Biopython chain object (that solves problems associated with disordered atoms)
+#!/usr/bin/env python3
 
-# Author: Jie Li
-# Date created: Sep 22, 2019
+from pathlib import Path
+from typing import Union
+
 
 class PDBSaver:
-    '''
-    Self-defined function for writing a PDB file from Biopython chain object
-    '''
-    def __init__(self):
-        self.structure=None
+    """Write a PDB file from a Biopython chain object, handling disordered atoms."""
 
-    def set_structure(self,structure):
-        self.structure=structure
+    def __init__(self) -> None:
+        self.structure = None
 
-    def save(self,address):
-        if self.structure==None:
+    def set_structure(self, structure) -> None:
+        self.structure = structure
+
+    def save(self, address: Union[str, Path]) -> None:
+        if self.structure is None:
             raise TypeError("Structure not set!")
-        else:
-            contents=[]
-            atom_counter=0
-            for residue in self.structure.get_residues():
-                for atom in residue.get_atoms():
-                    if atom.is_disordered():
-                        atom=atom.child_dict[sorted(atom.child_dict)[0]]
-                    atom_counter+=1
-                    contents.append("ATOM %6d%5s %3s %s %3d     %7.3f %7.3f %7.3f  1.00 %5.2f         %3s\n"%(atom_counter,atom.name,residue.resname,self.structure.id,residue.get_id()[1],atom.coord[0],atom.coord[1],atom.coord[2],atom.bfactor,atom.element))
-            with open(address,"w") as f:
-                f.writelines(contents)
+        contents = []
+        atom_counter = 0
+        for residue in self.structure.get_residues():
+            for atom in residue.get_atoms():
+                if atom.is_disordered():
+                    atom = atom.child_dict[sorted(atom.child_dict)[0]]
+                atom_counter += 1
+                contents.append(
+                    f"ATOM {atom_counter:6d}{atom.name:>5s} {residue.resname:3s} "
+                    f"{self.structure.id} {residue.get_id()[1]:3d}     "
+                    f"{atom.coord[0]:7.3f} {atom.coord[1]:7.3f} {atom.coord[2]:7.3f}"
+                    f"  1.00 {atom.bfactor:5.2f}         {atom.element:>3s}\n"
+                )
+        with open(address, "w") as f:
+            f.writelines(contents)

--- a/spartap_features.py
+++ b/spartap_features.py
@@ -1,300 +1,178 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Dec  8 12:11:25 2017
 
-@author: kcbennett
-"""
-
-
-
-#import os
-#import os.path
-#import sys
-#sys.path.append('/global/homes/m/mmartin8/.local/cori/2.7-anaconda-4.4/lib/python2.7/site-packages/')
-import pandas as pd
 import math
+import warnings
+import pandas as pd
+import numpy as np
 from Bio import PDB
 from Bio.PDB.PDBParser import PDBParser
-from Bio.SubsMat.MatrixInfo import blosum62
-from Bio.SeqUtils import IUPACData
-import warnings
+from Bio.Align import substitution_matrices
 from Bio import BiopythonWarning
-warnings.simplefilter('ignore', BiopythonWarning)
-import numpy as np
 
+try:
+    from Bio.Data import IUPACData
+except ImportError:
+    from Bio.SeqUtils import IUPACData  # biopython < 1.80
+
+warnings.simplefilter('ignore', BiopythonWarning)
+
+# ── Module-level constants ────────────────────────────────────────────────────
 
 atom_names = ['HA', 'H', 'CA', 'CB', 'C', 'N']
 
-#Wishart et al. in J-Bio NMR, 5 (1995) 67-81.
-paper_order = ['Ala', 'Cys','Asp','Glu','Phe','Gly','His','Ile','Lys','Leu','Met','Asn','Pro','Gln','Arg','Ser','Thr','Val','Trp','Tyr']
+_PAPER_ORDER = [
+    'ALA', 'CYS', 'ASP', 'GLU', 'PHE', 'GLY', 'HIS', 'ILE', 'LYS', 'LEU',
+    'MET', 'ASN', 'PRO', 'GLN', 'ARG', 'SER', 'THR', 'VAL', 'TRP', 'TYR',
+]
 
-paper_order = [i.upper() for i in paper_order]
+BLOSUM62 = substitution_matrices.load("BLOSUM62")
 
-# AAlist = [sorted(list(IUPACData.protein_letters_3to1.keys()))[i].upper()
-#           for i in range(20)]
-
-rc_ala = {}
-rc_ala['N'] = [123.8, 118.8, 120.4, 120.2, 120.3, 108.8, 118.2, 119.9,
-               120.4, 121.8, 119.6, 118.7, np.nan, 119.8, 120.5, 115.7,
-               113.6, 119.2, 121.3, 120.3]
-rc_ala['H'] = [8.24, 8.32, 8.34, 8.42, 8.30, 8.33, 8.42, 8.00,
-               8.29, 8.16, 8.28, 8.40, np.nan, 8.32, 8.23, 8.31, 8.15, 8.03,
-               8.25, 8.12]
-rc_ala['HA'] = [4.32, 4.55, 4.71, 4.64, 4.35, 4.62, 3.96, 4.73, 4.17, 4.32,
-                4.34, 4.48, 4.74, 4.42, 4.34, 4.3, 4.47, 4.35, 4.12, 4.66,
-                4.55]
-rc_ala['C'] = [177.8, 174.6, 176.3, 176.6, 175.8, 174.9, 174.1, 176.4, 176.6,
-               177.6, 176.3, 175.2, 177.3, 176.0, 176.3, 174.6, 174.7, 176.3,
-               176.1, 175.9]
-rc_ala['CA'] = [52.5, 58.2, 54.2, 56.6, 57.7, 45.1, 55.0, 61.1,
-                56.2, 55.1, 55.4, 53.1, 63.3, 55.7, 56.0, 58.3, 61.8, 62.2,
-                57.5, 57.9]
-rc_ala['CB'] = [19.1, 28, 41.1, 29.9, 39.6, np.nan, 29, 38.8, 33.1,
-                42.4, 32.9, 38.9, 32.1, 29.4, 30.9, 63.8, 69.8, 32.9, 29.6,
-                38.8]
-randcoil_ala = {i: dict(zip(paper_order, rc_ala[i])) for i in atom_names}
-# When the residue in question is followed by a Proline, we instead use:
-rc_pro = {}
-rc_pro['N'] = [125, 119.9, 121.4, 121.7, 120.9, 109.1, 118.2, 121.7, 121.6,
-               122.6, 120.7, 119.0, np.nan, 120.6, 121.3, 116.6, 116.0, 120.5,
-               122.2, 120.8]
-rc_pro['H'] = [8.19, 8.30, 8.31, 8.34, 8.13, 8.21, 8.37, 8.06, 8.18,
-               8.14, 8.25, 8.37, np.nan, 8.29, 8.2, 8.26, 8.15, 8.02, 8.09,
-               8.1]
-rc_pro['HA'] = [4.62, 4.81, 4.90, 4.64, 4.9, 4.13, 5.0, 4.47, 4.60, 4.63, 4.82,
-                5.0, 4.73, 4.65, 4.65, 4.78, 4.61, 4.44, 4.99, 4.84]
-rc_pro['C'] = [175.9, 173, 175, 174.9, 174.4, 174.5, 172.6, 175.0, 174.8,
-               175.7, 174.6, 173.6, 171.4, 174.4, 174.5, 173.1, 173.2, 174.9,
-               174.8, 174.8]
-rc_pro['CA'] = [50.5, 56.4, 52.2, 54.2, 55.6, 44.5, 53.3, 58.7, 54.2, 53.1,
-                53.3, 51.3, 61.5, 53.7, 54.0, 56.4, 59.8, 59.8, 55.7, 55.8]
-rc_pro['CB'] = [18.1, 27.1, 40.9, 29.2, 39.1, np.nan, 29.0, 38.7, 32.6, 41.7,
-                32.4, 38.7, 30.9, 28.8, 30.2, 63.3, 69.8, 32.6, 28.9, 38.3]
-randcoil_pro = {i: dict(zip(paper_order, rc_pro[i])) for i in atom_names}
+# Wishart et al., J-Bio NMR 5 (1995) 67-81.
+_rc_ala: dict[str, list] = {
+    'N':  [123.8, 118.8, 120.4, 120.2, 120.3, 108.8, 118.2, 119.9, 120.4, 121.8,
+           119.6, 118.7, np.nan, 119.8, 120.5, 115.7, 113.6, 119.2, 121.3, 120.3],
+    'H':  [8.24, 8.32, 8.34, 8.42, 8.30, 8.33, 8.42, 8.00, 8.29, 8.16,
+           8.28, 8.40, np.nan, 8.32, 8.23, 8.31, 8.15, 8.03, 8.25, 8.12],
+    'HA': [4.32, 4.55, 4.71, 4.64, 4.35, 4.62, 3.96, 4.73, 4.17, 4.32,
+           4.34, 4.48, 4.74, 4.42, 4.34, 4.3, 4.47, 4.35, 4.12, 4.66, 4.55],
+    'C':  [177.8, 174.6, 176.3, 176.6, 175.8, 174.9, 174.1, 176.4, 176.6, 177.6,
+           176.3, 175.2, 177.3, 176.0, 176.3, 174.6, 174.7, 176.3, 176.1, 175.9],
+    'CA': [52.5, 58.2, 54.2, 56.6, 57.7, 45.1, 55.0, 61.1, 56.2, 55.1,
+           55.4, 53.1, 63.3, 55.7, 56.0, 58.3, 61.8, 62.2, 57.5, 57.9],
+    'CB': [19.1, 28, 41.1, 29.9, 39.6, np.nan, 29, 38.8, 33.1, 42.4,
+           32.9, 38.9, 32.1, 29.4, 30.9, 63.8, 69.8, 32.9, 29.6, 38.8],
+}
+_rc_pro: dict[str, list] = {
+    'N':  [125, 119.9, 121.4, 121.7, 120.9, 109.1, 118.2, 121.7, 121.6, 122.6,
+           120.7, 119.0, np.nan, 120.6, 121.3, 116.6, 116.0, 120.5, 122.2, 120.8],
+    'H':  [8.19, 8.30, 8.31, 8.34, 8.13, 8.21, 8.37, 8.06, 8.18, 8.14,
+           8.25, 8.37, np.nan, 8.29, 8.2, 8.26, 8.15, 8.02, 8.09, 8.1],
+    'HA': [4.62, 4.81, 4.90, 4.64, 4.9, 4.13, 5.0, 4.47, 4.60, 4.63, 4.82,
+           5.0, 4.73, 4.65, 4.65, 4.78, 4.61, 4.44, 4.99, 4.84],
+    'C':  [175.9, 173, 175, 174.9, 174.4, 174.5, 172.6, 175.0, 174.8, 175.7,
+           174.6, 173.6, 171.4, 174.4, 174.5, 173.1, 173.2, 174.9, 174.8, 174.8],
+    'CA': [50.5, 56.4, 52.2, 54.2, 55.6, 44.5, 53.3, 58.7, 54.2, 53.1,
+           53.3, 51.3, 61.5, 53.7, 54.0, 56.4, 59.8, 59.8, 55.7, 55.8],
+    'CB': [18.1, 27.1, 40.9, 29.2, 39.1, np.nan, 29.0, 38.7, 32.6, 41.7,
+           32.4, 38.7, 30.9, 28.8, 30.2, 63.3, 69.8, 32.6, 28.9, 38.3],
+}
+randcoil_ala = {atom: dict(zip(_PAPER_ORDER, _rc_ala[atom])) for atom in atom_names}
+randcoil_pro = {atom: dict(zip(_PAPER_ORDER, _rc_pro[atom])) for atom in atom_names}
 oxidized_cys_correction = {"H": 0.11, "HA": 0.16, "C": 0, "CA": -2.8, "CB": 13.1, "N": -0.2}
 
-secondary_struc_dict = dict(zip(['H', 'B', 'E', 'G', 'I', 'T', 'S', '-'], [list(np.identity(8)[i]) for i in range(8)]))
-max_asa_dict = dict(zip(paper_order, [121.0, 148.0, 187.0, 214.0, 228.0, 97.0, 216.0, 195.0, 230.0, 191.0, 203.0, 187.0, 154.0, 214.0, 265.0, 143.0, 163.0, 165.0, 264.0, 255.0]))
+secondary_struc_dict = dict(zip(
+    ['H', 'B', 'E', 'G', 'I', 'T', 'S', '-'],
+    [list(np.identity(8)[i]) for i in range(8)],
+))
+max_asa_dict = dict(zip(
+    _PAPER_ORDER,
+    [121.0, 148.0, 187.0, 214.0, 228.0, 97.0, 216.0, 195.0, 230.0, 191.0,
+     203.0, 187.0, 154.0, 214.0, 265.0, 143.0, 163.0, 165.0, 264.0, 255.0],
+))
+
+# 3-letter → 1-letter mapping (uppercase keys)
+_THREE_TO_ONE = {k.upper(): v for k, v in IUPACData.protein_letters_3to1.items()}
+_ONE_TO_THREE = {v: k.upper() for k, v in IUPACData.protein_letters_3to1.items()}
 
 
-class BaseDataReader(object):
-    """ Base class for reading data files
+def _three_to_one(resname: str) -> str:
+    """Convert 3-letter residue code to 1-letter; returns 'X' if unknown."""
+    return _THREE_TO_ONE.get(resname.upper(), 'X')
 
-    The main function of any child of this class is to read a text file
-    in some relevant format and return a pandas DataFrame containing the
-    data in that file.
 
-    Args:
-        columns (list or iterator): column labels of resulting DataFrame
+# ── Base reader ───────────────────────────────────────────────────────────────
 
-    Attributes:
-        columns_ (list or iterator): column labels of resulting DataFrame
+class BaseDataReader:
+    """Base class for reading structure files into DataFrames."""
 
-    """
-
-    def __init__(self, columns):
+    def __init__(self, columns) -> None:
         self.columns_ = columns
 
-    def df_from_file(self, fpath):
-        """ Convert a file into a DataFrame
-
-        Args:
-            fpath (str): path to file
-
-        Returns:
-            pandas DataFrame with the column labels in columns_
-
-        """
+    def df_from_file(self, fpath: str) -> pd.DataFrame:
         raise NotImplementedError
 
 
+# ── PDB / SPARTA+ feature reader ─────────────────────────────────────────────
+
 class PDB_SPARTAp_DataReader(BaseDataReader):
-    """ Data Reader class for PDB files. Child of BaseDataReader
+    """Extract SPARTA+ and extended features from a PDB file."""
 
-    This class is designed to read PDB files and return DataFrame objects with all of
-    the relevant data. Each row in the DataFrame that is output by df_from_file
-    corresponds to a residue in the molecular structure described by the input PDB file.
-    The relevant columns then correspond to the residue index (a unique identifier that
-    connects the residue to the atoms it contains in the atom table) and a set of features to
-    be described below
+    COLS_ = {'FILE_ID': str, 'PDB_FILE_NAME': str, 'RES_NAME': str, 'PDB_RES_NUM': int, 'S2': float}
 
-    Attributes:
-        COLS_ (dict): dictionary mapping column names to data types
+    def __init__(self) -> None:
+        super().__init__(columns=PDB_SPARTAp_DataReader.COLS_.keys())
 
-    """
-#    COLS_ = {'FILE_ID': str,
-#             'PDB_FILE_NAME': str,
-#             'RES_NAME': str,
-#             'PDB_RES_NUM': int,
-#             'BLOSUM62_NUMS': list,
-#             'DIHEDRAL_PHI': list,
-#             'DIHEDRAL_PSI': list,
-#             'DIHEDRAL_CHI1': list,
-#             'DIHEDRAL_CHI2': list,
-#             'HBOND_PATTERN': list,
-#             'S2_ORDER_PARAM': float}
-
-    COLS_ = {'FILE_ID': str,
-             'PDB_FILE_NAME': str,
-             'RES_NAME': str,
-             'PDB_RES_NUM': int,
-             'S2': float}
-#
-#
-#    COLS_.update({'BLOSUM62_NUM_'+list(IUPACData.protein_letters_3to1.keys())[i].upper() + j: float)
-#    for j in ['', '_i-1', '_i', '_i+i'] for i in range(20)]})
-#    COLS_.update(dict([(i+j, float) for i in ['PHI_i-1', 'PSI_i+1', 'PHI_i', 'PSI_i', 'CHI1_i', 'CHI2_i'] for j in ['COS', 'SIN']]))
-#    COLS_.update(dict([(i+j, bool) for i in ['CHI1_i', 'CHI2_i'] for j in ['EXISTS']]))
-#    COLS_.update(dict([(i+j, float) for i in ['HN_i', 'HA_i', 'O_i', 'O_i-1', 'HN_i+1'] for j in ['COS_H', 'COS_A', 'd_HA']]))
-#    COLS_.update(dict([(i+j, bool) for i in ['HN_i', 'HA_i', 'O_i', 'O_i-1', 'HN_i+1'] for j in ['EXISTS']]))
-
-    def __init__(self):
-        super(PDB_SPARTAp_DataReader, self).__init__(columns=PDB_SPARTAp_DataReader.COLS_.keys())
+    # ── Static helpers ────────────────────────────────────────────────────────
 
     @staticmethod
-    def _fix_atom_type(start_atom_type):
-        '''
-        Fix improperly formatted atom types
-
-        This means moving any number at the start of thpandase string to
-        the end and changing Deuteriums to Hydrogens. E.g. if the
-        input is '1DG2', this becomes 'HG12'.
-
-        Args:
-            start_atom_type (str): inital atom type
-
-        Returns:
-            atom_type - The fixed atom type (str)
-        '''
-        
-        atom_type = [ch for ch in start_atom_type]
+    def _fix_atom_type(start_atom_type: str) -> str:
+        atom_type = list(start_atom_type)
         if atom_type[0].isnumeric():
-            atom_type.append(atom_type[0])
-            atom_type.pop(0)
+            atom_type.append(atom_type.pop(0))
         if atom_type[0] == 'D':
             atom_type[0] = 'H'
-        atom_type = ''.join(atom_type)
-        return atom_type
-
+        return ''.join(atom_type)
 
     @staticmethod
-    def _fix_res_name(start_res_name):
-        '''
-        Fix wrong residue names
+    def _fix_res_name(start_res_name: str) -> str:
+        return start_res_name if len(start_res_name) <= 3 else start_res_name[1:]
 
-        This is just removing extraneous capital letters at the front of some residue names
-        
-        Args:
-            start_res_name - Intital residue name (Str)
+    # ── Feature calculation methods ───────────────────────────────────────────
 
-        Returns:
-            res_name - The fixed residue name (Str)
-        '''
-        
-        res_name = start_res_name
-        if len(start_res_name) > 3:
-            res_name = start_res_name[1:]
-        return res_name
-
-
-    def get_bfactor(self, res_obj, atoms='all'):
-        '''Function to get the b-factor for a given residue.  Can return the average of [C, CA, CB, H, HA, O] atoms or average all atoms in the residue.
-        
-        args:
-            res_obj - Residue for which an average b-factor is desired (Biopython.PDB Residue object)
-            atoms - Which atoms' b-factors to average. Accepts "all" or "set6" (Str)
-            
-        returns:
-            bfact - Average b-factor (Float)
-        '''
-        btot = 0
+    def get_bfactor(self, res_obj, atoms: str = 'all') -> float:
+        btot = 0.0
         if atoms == 'all':
             at_list = list(res_obj.get_atoms())
             for atom in at_list:
                 btot += atom.get_bfactor()
-            bfact = btot / len(at_list)
-        if atoms == 'set6':
-            for at in ['H', '1H', 'H1', 'D', '1D', 'D1']:
-                try:
-                    HNatom = res_obj[at]
-                    btot += HNatom.get_bfactor()
-                    break
-                except KeyError:
-                    HNatom = None
-            for at in ['HA', '1HA']:
-                try:
-                    HAatom = res_obj[at]
-                    btot += HAatom.get_bfactor()
-                    break
-                except KeyError:
-                    HAatom = None
-            for at in ['N', 'C', 'CA', 'CB']:
-                try:
-                    this_atom = res_obj[at]
-                    btot += this_atom.get_bfactor()
-                except KeyError:
-                    pass
-            bfact = btot / 6
-        return bfact
-                
-    
-    def blosum_nums(self, res_obj):
-        '''
-        Get blosum62 block substitution matrix comparison numbers
+            return btot / len(at_list)
+        # atoms == 'set6'
+        for at in ['H', '1H', 'H1', 'D', '1D', 'D1']:
+            try:
+                btot += res_obj[at].get_bfactor()
+                break
+            except KeyError:
+                pass
+        for at in ['HA', '1HA']:
+            try:
+                btot += res_obj[at].get_bfactor()
+                break
+            except KeyError:
+                pass
+        for at in ['N', 'C', 'CA', 'CB']:
+            try:
+                btot += res_obj[at].get_bfactor()
+            except KeyError:
+                pass
+        return btot / 6
 
-        Args:
-            res_obj - The residue that is being compared (Bio.PDB.Residue)
-
-        Returns:
-            nums - The 20 blosum62 comparison numbers (list of floats) or [0]*20 if residue not found (np.Array of Int)
-       '''
-
-        # First need to convert blosum62 dictionary to 3-letter codes
-        cap_1to3 = dict((i, j.upper()) for i, j in IUPACData.protein_letters_1to3.items())
-        std_blosum62 = dict([(cap_1to3[i[0]], cap_1to3[i[1]]), j] for i,j in blosum62.items()
-        if i[0] not in ['Z', 'B', 'X'] and i[1] not in ['Z', 'B', 'X'])
-
-
+    def blosum_nums(self, res_obj) -> list:
+        """Return the 20 BLOSUM62 substitution scores for this residue in sorted AA order."""
         res_name = self._fix_res_name(res_obj.resname)
+        code1 = _THREE_TO_ONE.get(res_name)
+        if code1 is None or code1 not in BLOSUM62.alphabet:
+            return [0] * 20
+        # Return scores in alphabetical order of 3-letter codes (matching column naming)
+        aa_sorted = sorted(_THREE_TO_ONE.keys())  # alphabetical 3-letter codes
         nums = []
-        for key in sorted(std_blosum62):
-            if key[0]==res_name or key[1]==res_name:
-                nums.append(std_blosum62[key])
+        for aa in aa_sorted:
+            code2 = _THREE_TO_ONE[aa]
+            try:
+                nums.append(int(BLOSUM62[code1, code2]))
+            except (KeyError, IndexError):
+                nums.append(0)
         return nums
 
-
-    def binary_seqvecs(self, res_obj):
-        '''
-        Get a binary vector indicating which of the 20 standard amino acids the residue is
-
-        Args:
-            res_obj - The residue that is being classified (Bio.PDB.Residue)
-
-        Returns:
-            out - A list of 20 integers all but one of which are zeros and the remaining is a one. The position of the 1 element indicates which of the 20 standard amino acids the residue is.  If the residue is not one of the standard 20, returns [0]*20 (list of Int)
-        '''
-
+    def binary_seqvecs(self, res_obj) -> list:
         res_name = self._fix_res_name(res_obj.resname)
-        out = 0*[20]
-        for i, aa in enumerate(paper_order):
+        out = [0] * 20
+        for i, aa in enumerate(_PAPER_ORDER):
             if res_name == aa:
                 out[i] = 1
         return out
 
-
     @staticmethod
-    def calc_phi_psi(chain_obj):
-        '''
-        Get list of dihedral phi and psi angles
-
-        Args:
-            chain_obj - A chain of residues for which to calculate the dihedral angles (Bio.PDB.Chain)
-
-        Returns:
-            fin_list - A list of angle parameters[cos(phi), sin(phi), cos(psi), sin(psi)] with [0]*4 for the absence of an angle (List of Float)
-        '''
-
+    def calc_phi_psi(chain_obj) -> list:
         polys = PDB.PPBuilder(radius=2.1).build_peptides(chain_obj)
         phi_psi_list = []
         full_res_list = []
@@ -306,753 +184,457 @@ class PDB_SPARTAp_DataReader(BaseDataReader):
         out_list = []
         for peps in phi_psi_list:
             for ang_pair in peps:
-                if ang_pair[0] == None:
-                    phi_dat = [0, 0]
-                else:
-                    phi_dat = [math.cos(ang_pair[0]), math.sin(ang_pair[0])]
-                if ang_pair[1] == None:
-                    psi_dat =[0, 0]
-                else:
-                    psi_dat = [math.cos(ang_pair[1]), math.sin(ang_pair[1])]
+                phi_dat = [math.cos(ang_pair[0]), math.sin(ang_pair[0])] if ang_pair[0] is not None else [0, 0]
+                psi_dat = [math.cos(ang_pair[1]), math.sin(ang_pair[1])] if ang_pair[1] is not None else [0, 0]
                 out_list.append(phi_dat + psi_dat)
-        fin_list = [out_list[i] for i in range(len(out_list)) if (full_res_list[i].get_id()[2] == ' ')]
-        return fin_list
+        return [out_list[i] for i in range(len(out_list)) if full_res_list[i].get_id()[2] == ' ']
 
-
-    def calc_torsion_angles(self, res_obj, chi=[1,2]):
-        '''
-        Get list of chi angles
-
-        Args:
-            res_obj - A residue for which to calculate (Bio.PDB.Residue)
-            torsion angles
-            chi - A list of integers in range(1,6) that specify which chi angles to calculate.  Default is [1, 2] (List of Int)
-
-        Returns:
-            chi_list - The sum of lists of torsion angle parameters [cos(chi), sin(chi), 0/1], with the boolean indicating existence of the angle, for each of the chi
-        '''
-
-        # First need to construct a dictionary mapping the residue
-        # to the atoms defining each of the chi's
-
+    def calc_torsion_angles(self, res_obj, chi: list = None) -> list:
+        if chi is None:
+            chi = [1, 2]
         chi_defs = dict(
             chi1=dict(
-                ARG=['N', 'CA', 'CB', 'CG'],
-                ASN=['N', 'CA', 'CB', 'CG'],
-                ASP=['N', 'CA', 'CB', 'CG'],
-                CYS=['N', 'CA', 'CB', 'SG'],
-                GLN=['N', 'CA', 'CB', 'CG'],
-                GLU=['N', 'CA', 'CB', 'CG'],
-                HIS=['N', 'CA', 'CB', 'CG'],
-                ILE=['N', 'CA', 'CB', 'CG1'],
-                LEU=['N', 'CA', 'CB', 'CG'],
-                LYS=['N', 'CA', 'CB', 'CG'],
-                MET=['N', 'CA', 'CB', 'CG'],
-                PHE=['N', 'CA', 'CB', 'CG'],
-                PRO=['N', 'CA', 'CB', 'CG'],
-                SER=['N', 'CA', 'CB', 'OG'],
-                THR=['N', 'CA', 'CB', 'OG1'],
-                TRP=['N', 'CA', 'CB', 'CG'],
-                TYR=['N', 'CA', 'CB', 'CG'],
-                VAL=['N', 'CA', 'CB', 'CG1'],
-            ),
-            altchi1=dict(
-                VAL=['N', 'CA', 'CB', 'CG2'],
+                ARG=['N', 'CA', 'CB', 'CG'], ASN=['N', 'CA', 'CB', 'CG'],
+                ASP=['N', 'CA', 'CB', 'CG'], CYS=['N', 'CA', 'CB', 'SG'],
+                GLN=['N', 'CA', 'CB', 'CG'], GLU=['N', 'CA', 'CB', 'CG'],
+                HIS=['N', 'CA', 'CB', 'CG'], ILE=['N', 'CA', 'CB', 'CG1'],
+                LEU=['N', 'CA', 'CB', 'CG'], LYS=['N', 'CA', 'CB', 'CG'],
+                MET=['N', 'CA', 'CB', 'CG'], PHE=['N', 'CA', 'CB', 'CG'],
+                PRO=['N', 'CA', 'CB', 'CG'], SER=['N', 'CA', 'CB', 'OG'],
+                THR=['N', 'CA', 'CB', 'OG1'], TRP=['N', 'CA', 'CB', 'CG'],
+                TYR=['N', 'CA', 'CB', 'CG'], VAL=['N', 'CA', 'CB', 'CG1'],
             ),
             chi2=dict(
-                ARG=['CA', 'CB', 'CG', 'CD'],
-                ASN=['CA', 'CB', 'CG', 'OD1'],
-                ASP=['CA', 'CB', 'CG', 'OD1'],
-                GLN=['CA', 'CB', 'CG', 'CD'],
-                GLU=['CA', 'CB', 'CG', 'CD'],
-                HIS=['CA', 'CB', 'CG', 'ND1'],
-                ILE=['CA', 'CB', 'CG1', 'CD1'],
-                LEU=['CA', 'CB', 'CG', 'CD1'],
-                LYS=['CA', 'CB', 'CG', 'CD'],
-                MET=['CA', 'CB', 'CG', 'SD'],
-                PHE=['CA', 'CB', 'CG', 'CD1'],
-                PRO=['CA', 'CB', 'CG', 'CD'],
-                TRP=['CA', 'CB', 'CG', 'CD1'],
-                TYR=['CA', 'CB', 'CG', 'CD1'],
-            ),
-            altchi2=dict(
-                ASP=['CA', 'CB', 'CG', 'OD2'],
-                LEU=['CA', 'CB', 'CG', 'CD2'],
-                PHE=['CA', 'CB', 'CG', 'CD2'],
-                TYR=['CA', 'CB', 'CG', 'CD2'],
-            ),
-            chi3=dict(
-                ARG=['CB', 'CG', 'CD', 'NE'],
-                GLN=['CB', 'CG', 'CD', 'OE1'],
-                GLU=['CB', 'CG', 'CD', 'OE1'],
-                LYS=['CB', 'CG', 'CD', 'CE'],
-                MET=['CB', 'CG', 'SD', 'CE'],
-            ),
-            chi4=dict(
-                ARG=['CG', 'CD', 'NE', 'CZ'],
-                LYS=['CG', 'CD', 'CE', 'NZ'],
-            ),
-            chi5=dict(
-                ARG=['CD', 'NE', 'CZ', 'NH1'],
+                ARG=['CA', 'CB', 'CG', 'CD'], ASN=['CA', 'CB', 'CG', 'OD1'],
+                ASP=['CA', 'CB', 'CG', 'OD1'], GLN=['CA', 'CB', 'CG', 'CD'],
+                GLU=['CA', 'CB', 'CG', 'CD'], HIS=['CA', 'CB', 'CG', 'ND1'],
+                ILE=['CA', 'CB', 'CG1', 'CD1'], LEU=['CA', 'CB', 'CG', 'CD1'],
+                LYS=['CA', 'CB', 'CG', 'CD'], MET=['CA', 'CB', 'CG', 'SD'],
+                PHE=['CA', 'CB', 'CG', 'CD1'], PRO=['CA', 'CB', 'CG', 'CD'],
+                TRP=['CA', 'CB', 'CG', 'CD1'], TYR=['CA', 'CB', 'CG', 'CD1'],
             ),
         )
-
-        # Next construct a list of the names of desired angles
-        chi_names = []
-        for x in chi:
-            reg_chi = "chi%s" % x
-            if reg_chi in chi_defs.keys():
-                chi_names.append(reg_chi)
-    #            This can be activated to implement alt_chi defs
-    #            alt_chi = "altchi%s" % x
-    #            if alt_chi in chi_defs.keys():
-    #                chi_names.append(alt_chi)
-            else:
-                pass
-
-
-        # Construct list of triples that define the requested chi angles
-        # The triples are cos, sin, existence with [0,0,0] convention for nan
         res_name = self._fix_res_name(res_obj.resname)
         chi_list = []
-        for chis in chi_names:
-            # Skip heteroatoms...this may need to be modified or expanded
+        for chi_idx in chi:
+            key = f"chi{chi_idx}"
+            if key not in chi_defs:
+                chi_list += [0, 0, 0]
+                continue
             if res_obj.id[0] != " ":
-                chi_list = [0]*3*len(chi)
+                chi_list += [0] * 3 * len(chi)
                 break
-            chi_res = chi_defs[chis]
             try:
-                atom_list = chi_res[res_name]
-                try:
-                    vec_atoms = [res_obj[i] for i in atom_list]
-                    vectors = [i.get_vector() for i in vec_atoms]
-                    angle = PDB.calc_dihedral(*vectors)
-                    chi_list += [math.cos(angle), math.sin(angle), 1]
-                except KeyError:
-                    chi_list += [0, 0, 0]
+                atom_list = chi_defs[key][res_name]
+                vec_atoms = [res_obj[a] for a in atom_list]
+                vectors = [a.get_vector() for a in vec_atoms]
+                angle = PDB.calc_dihedral(*vectors)
+                chi_list += [math.cos(angle), math.sin(angle), 1]
             except KeyError:
                 chi_list += [0, 0, 0]
-
         return chi_list
 
-
     @staticmethod
-    def s2_param(nn_tree, res_obj, chain, rad=10.0, b_param=-0.1):
-        '''
-        Calculate S2 order parameter of N-H bond based on the contact model put forth in Zhang, Bruschweiler (2002) J. Am. Chem. Soc 124
-
-        Args:
-            nn_tree - A tree containing the distances between atoms in the set of interest (Bio.PDB.NeighborSearch)
-            res_obj - The residue for which we are calculating S2 (Bio.PDB.Residue)
-            prev_Oatom - The Oxygen atom for the previous residue in the chain (Bio.PDB.Atom)
-            rad - The radius within which to search for heavy atoms to include in the contact model.  Note that, in principle, we could use different radii for the rOsum and rHsum in the model (Float)
-            b_param - A parameter in the model (Float)
-
-        Returns:
-            S2 - The S2 order parameter for the N-H bond of res_obj (Float)
-        '''
-
-        rOsum = 0
-        rHsum = 0
-
+    def s2_param(nn_tree, res_obj, chain, rad: float = 10.0, b_param: float = -0.1) -> float:
+        rOsum = 0.0
+        rHsum = 0.0
         try:
-            prev_res = chain[res_obj.get_id()[1]-1]
+            prev_res = chain[res_obj.get_id()[1] - 1]
         except KeyError:
             prev_res = None
-
-
-        if prev_res != None:
-            try:
-                prev_Oatom = prev_res['O']
-            except KeyError:
-                prev_Oatom = None
-        else:
+        prev_Oatom = prev_res['O'] if prev_res is not None else None
+        try:
+            prev_Oatom = prev_res['O']
+        except (KeyError, TypeError):
             prev_Oatom = None
 
-
-        if prev_Oatom != None:
-            nn_atoms = nn_tree.search(prev_Oatom.get_coord(), rad, level='A')
-            for atom in nn_atoms:
-                if ('H' not in atom.get_name()) and (atom - prev_Oatom) > 0.1:
+        if prev_Oatom is not None:
+            for atom in nn_tree.search(prev_Oatom.get_coord(), rad, level='A'):
+                if 'H' not in atom.get_name() and (atom - prev_Oatom) > 0.1:
                     at_res = atom.get_parent()
-                    if (at_res != res_obj) and (at_res != prev_res):
+                    if at_res != res_obj and at_res != prev_res:
                         rOsum += math.exp(-(atom - prev_Oatom - 1.2))
-                else:
-                    pass
-        else:
-            pass
 
         for at in ['H', '1H']:
             try:
                 Hatom = res_obj[at]
-                nn_atoms = nn_tree.search(Hatom.get_coord(), rad, level='A')
-                for atom in nn_atoms:
-                    if ('H' not in atom.get_name()) and (atom - Hatom) > 0.1:
+                for atom in nn_tree.search(Hatom.get_coord(), rad, level='A'):
+                    if 'H' not in atom.get_name() and (atom - Hatom) > 0.1:
                         at_res = atom.get_parent()
-                        if (at_res != res_obj) and (at_res != prev_res):
+                        if at_res != res_obj and at_res != prev_res:
                             rHsum += math.exp(-(atom - Hatom - 1.2))
-                    else:
-                        pass
                 break
             except KeyError:
                 pass
 
-        S2 = math.tanh(0.8 * (rOsum + rHsum)) + b_param
-        return S2
-
+        return math.tanh(0.8 * (rOsum + rHsum)) + b_param
 
     @staticmethod
-    def find_nearest_atom(nn_tree, catom, rad, inrad=0.5, atom_type='Any', excl=[]):
-        '''
-        Find the nearest atom of type atom_type within radius rad of a central atom catom. Note that the function finds the closest atom that contains the atom_type string in its name rather than relying on an exact match.
-
-        Args:
-            nn_tree - A tree containing the distances between atoms in the set of interest (Bio.PDB.NeighborSearch)
-            catom - Central atom for which we wish to find the nearest neighbor (Bio.PDB.Atom)
-            rad - The distance within which to search (Float)
-            atom_type - The type of atom for which to search. Default is to search for any atom (Str)
-            excl - List of atom objects to exclude from the search(List of Bio.PDB.Atom)
-
-        Returns:
-            nn_atom - The nearest atom_type atom within rad of catom.  Returns None if no such atom found within rad of catom (Bio.PDB.Atom)
-        '''
-
-        coord = catom.get_coord()
-        atoms = nn_tree.search(coord, rad)
-        dists = []
-        for atom in atoms:
-            dists.append(atom-catom)
-        # dists = [atom - catom for atom in atoms]
-
-        # If only a single atom within rad, return that info now
-        if len(dists) == 1:
-#            print('There are no other atoms within rad of catom')
+    def find_nearest_atom(nn_tree, catom, rad: float, inrad: float = 0.5, atom_type='Any', excl: list = None):
+        if excl is None:
+            excl = []
+        atoms = nn_tree.search(catom.get_coord(), rad)
+        dists = [atom - catom for atom in atoms]
+        if len(dists) <= 1:
             return None
 
-        # Initializae min distance and corresponding index with upper bounds
-        # Will use the possible IndexError to indicate no atoms found
-
         d_min = rad
-        loc = 10**10
+        loc = None
 
-        # If no specified type, just find the atom with min distance but
-        # remember to exclude the atom at coord (we use a 0.1 exclusion ball)
         if atom_type == 'Any':
             for idx, dist in enumerate(dists):
-                if dist < d_min and dist > inrad and dist > 0.1:
-                    at = atoms[idx]
-                    if at not in excl:
+                if inrad < dist < d_min and dist > 0.1 and atoms[idx] not in excl:
+                    d_min = dist
+                    loc = idx
+        elif isinstance(atom_type, list):
+            for idx, dist in enumerate(dists):
+                if inrad < dist < d_min and dist > 0.1:
+                    if atoms[idx].element in atom_type and atoms[idx] not in excl:
                         d_min = dist
                         loc = idx
-            try:
-                nn_atom = atoms[loc]
-                return nn_atom
-            except IndexError:
-#                print('There are no atoms within rad of coord')
-                return None
-        # If type specified, need to check that it is in atom name
-        # If none found, return None
-        elif type(atom_type) == list:
-            for idx, dist in enumerate(dists):
-                at = atoms[idx]
-                atom_elem = at.element
-                if dist < d_min and dist > inrad and dist > 0.1:
-                    for atype in atom_type:
-                        if (atype == atom_elem) and (at not in excl):
-                                d_min = dist
-                                loc = idx
-            try:
-                nn_atom = atoms[loc]
-                return nn_atom
-            except IndexError:
-#                print('There are no atoms within rad of coord')
-                return None
-            
         else:
             for idx, dist in enumerate(dists):
-                atom_elem = atoms[idx].element
-                if dist < d_min and dist > inrad and dist > 0.1 and (atom_type == atom_elem):
-                    at = atoms[idx]
-                    if at not in excl:
+                if inrad < dist < d_min and dist > 0.1:
+                    if atoms[idx].element == atom_type and atoms[idx] not in excl:
                         d_min = dist
                         loc = idx
-            try:
-                nn_atom = atoms[loc]
-                return nn_atom
-            except IndexError:
-#                print('There are no atoms of atom_type within rad of coord')
-                return None
 
+        return atoms[loc] if loc is not None else None
 
     @staticmethod
-    def find_nxtnearest_Atom(nn_tree, catom, rad, atom_type='Any', excl=[]):
-        '''
-        Find the next nearest atom of type atom_type within radius rad of a central atom catom. Note that the function finds the closest atom that contains the atom_type string in its name rather than relying on an exact match.
-        
-        Args:
-            nn_tree - A tree containing the distances between atoms in the set of interest (Bio.PDB.NeighborSearch)
-            catom - Central atom for which we wish to find the next nearest neighbor (Bio.PDB.Atom)
-            rad - The distance within which to search (Float)
-            atom_type - The type of atom for which to search. Default is to search for any atom (Str)
-            excl - List of atom objects to exclude from the search (List of Bio.PDB.Atom)
-
-        Returns:
-            nxtnn_atom - The next nearest atom_type atom within rad of catom.  Returns None if no such atom found within rad of catom (Bio.PDB.Atom)
-        '''
-# SHOULD UPDATE THIS FUNCTION TO LOOK AT ATOMIC ELEMENTS RATHER THAN ATOM NAMES AS WELL AS TO ACCEPT LISTS FOR ATOM_TYPE KWARG
-        coord = catom.get_coord()
-        atoms = nn_tree.search(coord, rad)
-        dists = []
-        for atom in atoms:
-            dists.append(atom-catom)
-
-    #    If only a single atom within rad, return that info now
+    def find_nxtnearest_Atom(nn_tree, catom, rad: float, atom_type='Any', excl: list = None):
+        if excl is None:
+            excl = []
+        atoms = nn_tree.search(catom.get_coord(), rad)
+        dists = [atom - catom for atom in atoms]
         if len(dists) < 3:
-#            print('There are fewer than two atoms within rad of coord')
-            return None#
-        d_min, d_2min = rad, rad
-        min_loc, min_loc2 = 10**10, 10**10
+            return None
+
+        d_min = d_2min = rad
+        min_loc = min_loc2 = None
 
         if atom_type == 'Any':
             for idx, dist in enumerate(dists):
                 if dist < d_min and dist > 0.1:
-                    d_2min = d_min
-                    d_min = dist
-                    min_loc2 = min_loc
-                    min_loc = idx
-                elif dist < d_2min and dist > d_min:
+                    d_2min, d_min = d_min, dist
+                    min_loc2, min_loc = min_loc, idx
+                elif d_min < dist < d_2min:
                     d_2min = dist
                     min_loc2 = idx
-            nxtnn_atom = atoms[min_loc2]
-            return nxtnn_atom
         else:
             for idx, dist in enumerate(dists):
                 atom_name = atoms[idx].name
-                if dist < d_min and dist > 0.1 and (atom_type in atom_name):
-                    d_2min = d_min
-                    d_min = dist
-                    min_loc2 = min_loc
-                    min_loc = idx
-                elif dist < d_2min and dist > d_min and (atom_type in atom_name):
+                if dist < d_min and dist > 0.1 and atom_type in atom_name:
+                    d_2min, d_min = d_min, dist
+                    min_loc2, min_loc = min_loc, idx
+                elif d_min < dist < d_2min and atom_type in atom_name:
                     d_2min = dist
                     min_loc2 = idx
-            try:
-                nxtnn_atom = atoms[min_loc2]
-                return nxtnn_atom
-            except IndexError:
-#                print('There are fewer than two atoms of atom_type within rad of coord')
-                return None
 
+        return atoms[min_loc2] if min_loc2 is not None else None
 
-    def calc_ring_currents(self, res_object_list):
-        '''
-        Takes list of residues and returns a dictionary of atom specific ring current shifts with residue numbers as keys. Note that this assumes that residues in the list have unique numbers.
-        
-        Args:
-            res_object_list - List of Residue objects that may contain rings (List of Bio.PDB.Residue)
-        
-        Returns:
-            res_ring_shift_dict - Dictionary where keys are atoms in the residues in the given list and values are corresponding ring current contributions to the chemical shifts (Dict)
-        '''
+    def calc_ring_currents(self, res_object_list: list) -> dict:
+        res_numbers = [r.get_id()[1] for r in res_object_list]
+        if len(res_numbers) > len(set(res_numbers)):
+            raise ValueError('Not all residue numbers are unique in calc_ring_currents')
 
-        #Make sure all residues have unique numbers
-        res_numbers = [i.get_id()[1] for i in res_object_list]
-        if len(res_numbers)>len(set(res_numbers)):
-            raise Exception('Not all residue numbers are unique in calc_ring_currents res_object_list')
-
-
-        #Parameters from shiftX
-        atom_names_target = ['C', 'CA', 'CB', 'N', 'HA', 'HA2', 'HA3', 'H', '1H', '1HA', '2HA']
         intensity_factors = {'PHE': 1.05, 'TYR': 0.92, 'TRP1': 1.04, 'TRP2': 0.90, 'HIS': 0.43}
-        target_factors = {'HA': 5.13, 'HA2': 5.13, 'HA3': 5.13, 'H': 7.06, 'CA': 1.5, 'CB': 1.00, 'N': 1.00, 'C': 1.00, '1HA' : 5.13, '2HA' : 5.13, '1H' : 7.06}
+        target_factors = {'HA': 5.13, 'HA2': 5.13, 'HA3': 5.13, 'H': 7.06, 'CA': 1.5,
+                          'CB': 1.00, 'N': 1.00, 'C': 1.00, '1HA': 5.13, '2HA': 5.13, '1H': 7.06}
+        atom_names_target = list(target_factors.keys())
 
-
-        #Get list of rings and associated coordinates
         rings = []
         for res in res_object_list:
             try:
-                if (res.get_resname() == 'PHE'):
-                    rings += [['PHE',(res['CG'].get_coord(), res['CD2'].get_coord(), res['CE2'].get_coord(), res['CZ'].get_coord(), res['CE1'].get_coord(), res['CD1'].get_coord())]]
-                elif (res.get_resname()=='TYR'):
-                    rings += [['TYR',(res['CG'].get_coord(), res['CD2'].get_coord(), res['CE2'].get_coord(), res['CZ'].get_coord(), res['CE1'].get_coord(), res['CD1'].get_coord())]]
-                elif (res.get_resname() == 'TRP'):
-                    rings += [['TRP1',(res['CD2'].get_coord(), res['CE3'].get_coord(), res['CZ3'].get_coord(), res['CH2'].get_coord(), res['CZ2'].get_coord(), res['CE2'].get_coord())]]
-                    rings += [['TRP2',(res['CG'].get_coord(), res['CD2'].get_coord(), res['CE2'].get_coord(), res['NE1'].get_coord(), res['CD1'].get_coord())]]
-                elif (res.get_resname() == 'HIS'):
-                    rings += [['HIS',(res['CG'].get_coord(), res['ND1'].get_coord(), res['CE1'].get_coord(), res['NE2'].get_coord(), res['CD2'].get_coord())]]
-            except:
-                #Every once in a while a sidechain will be missing. These res will be excluded in the end.
+                name = res.get_resname()
+                if name == 'PHE':
+                    rings.append(['PHE', (res['CG'].get_coord(), res['CD2'].get_coord(),
+                                          res['CE2'].get_coord(), res['CZ'].get_coord(),
+                                          res['CE1'].get_coord(), res['CD1'].get_coord())])
+                elif name == 'TYR':
+                    rings.append(['TYR', (res['CG'].get_coord(), res['CD2'].get_coord(),
+                                          res['CE2'].get_coord(), res['CZ'].get_coord(),
+                                          res['CE1'].get_coord(), res['CD1'].get_coord())])
+                elif name == 'TRP':
+                    rings.append(['TRP1', (res['CD2'].get_coord(), res['CE3'].get_coord(),
+                                           res['CZ3'].get_coord(), res['CH2'].get_coord(),
+                                           res['CZ2'].get_coord(), res['CE2'].get_coord())])
+                    rings.append(['TRP2', (res['CG'].get_coord(), res['CD2'].get_coord(),
+                                           res['CE2'].get_coord(), res['NE1'].get_coord(),
+                                           res['CD1'].get_coord())])
+                elif name == 'HIS':
+                    rings.append(['HIS', (res['CG'].get_coord(), res['ND1'].get_coord(),
+                                          res['CE1'].get_coord(), res['NE2'].get_coord(),
+                                          res['CD2'].get_coord())])
+            except Exception:
                 print('error on ring')
 
-
-
-        #Calculate contribution from each ring on each atom
-        res_ring_shift_dict = {}
+        res_ring_shift_dict: dict = {}
         for res in res_object_list:
             resnum = res.get_id()[1]
-            target_atoms = [i for i in res.get_atoms() if i.get_id() in atom_names_target]
+            target_atoms = [a for a in res.get_atoms() if a.get_id() in atom_names_target]
             for atom in target_atoms:
-                shift = 0
+                shift = 0.0
                 for ring in rings:
-                    G = 0
                     ring_coords = ring[1]
-                    normal = np.cross(ring_coords[1]-ring_coords[0], ring_coords[-1]-ring_coords[0])
-                    normal = normal/np.linalg.norm(normal)
-                    o = atom.get_coord() + np.dot(normal, ring_coords[0]-atom.get_coord())*normal
+                    normal = np.cross(ring_coords[1] - ring_coords[0], ring_coords[-1] - ring_coords[0])
+                    normal = normal / np.linalg.norm(normal)
+                    o = atom.get_coord() + np.dot(normal, ring_coords[0] - atom.get_coord()) * normal
+                    G = 0.0
                     for i in range(len(ring_coords)):
-                        if (i == (len(ring_coords)-1)):
-                            r_i = ring_coords[i] - o
-                            r_j = ring_coords[0] - o
-                            d_r_i = ring_coords[i] - atom.get_coord()
-                            d_r_j = ring_coords[0] - atom.get_coord()
-                            area_ij = np.linalg.norm(np.cross(r_i, r_j))/2
-                            sign = np.sign( np.dot(np.cross(r_i, r_j), normal) )
-                            area_ij = sign*area_ij
-                            d_ij = 1/(np.linalg.norm(d_r_i)**3) + 1/(np.linalg.norm(d_r_j)**3)
-                        else:
-                            r_i = ring_coords[i] - o
-                            r_j = ring_coords[i+1] - o
-                            d_r_i = ring_coords[i] - atom.get_coord()
-                            d_r_j = ring_coords[i+1] - atom.get_coord()
-                            area_ij = np.linalg.norm(np.cross(r_i, r_j))/2
-                            sign = np.sign( np.dot(np.cross(r_i, r_j), normal) )
-                            area_ij = sign*area_ij
-                            d_ij = 1/(np.linalg.norm(d_r_i)**3) + 1/(np.linalg.norm(d_r_j)**3)
-                        G = G+d_ij*area_ij
-                    I = intensity_factors[ring[0]]
-                    F = target_factors[atom.get_id()]
-                    shift += G*I*F
+                        j = 0 if i == len(ring_coords) - 1 else i + 1
+                        r_i = ring_coords[i] - o
+                        r_j = ring_coords[j] - o
+                        d_r_i = ring_coords[i] - atom.get_coord()
+                        d_r_j = ring_coords[j] - atom.get_coord()
+                        area_ij = np.linalg.norm(np.cross(r_i, r_j)) / 2
+                        sign = np.sign(np.dot(np.cross(r_i, r_j), normal))
+                        area_ij *= sign
+                        d_ij = 1 / np.linalg.norm(d_r_i) ** 3 + 1 / np.linalg.norm(d_r_j) ** 3
+                        G += d_ij * area_ij
+                    shift += G * intensity_factors[ring[0]] * target_factors[atom.get_id()]
 
-                if resnum in res_ring_shift_dict.keys():
-                    res_ring_shift_dict[resnum][atom.get_id()+'_RING']=shift
-                else:
-                    res_ring_shift_dict[resnum]={}
-                    res_ring_shift_dict[resnum][atom.get_id()+'_RING']=shift
+                if resnum not in res_ring_shift_dict:
+                    res_ring_shift_dict[resnum] = {}
+                res_ring_shift_dict[resnum][atom.get_id() + '_RING'] = shift
 
-
-            included_atoms = [i.split('_')[0] for i in res_ring_shift_dict[resnum].keys()]
-            remaining_atoms = [i for i in atom_names_target if i not in included_atoms]
-            for a in remaining_atoms:
-                res_ring_shift_dict[resnum][a+'_RING'] = np.nan
-            if res_ring_shift_dict[resnum]['H_RING'] is np.nan:
-                res_ring_shift_dict[resnum]['H_RING'] = res_ring_shift_dict[resnum]['1H_RING']
-            if res_ring_shift_dict[resnum]['HA_RING'] is np.nan:
-                res_ring_shift_dict[resnum]['HA_RING'] = res_ring_shift_dict[resnum]['1HA_RING']
+            included = [k.split('_')[0] for k in res_ring_shift_dict.get(resnum, {})]
+            for a in [x for x in atom_names_target if x not in included]:
+                res_ring_shift_dict.setdefault(resnum, {})[a + '_RING'] = np.nan
+            d = res_ring_shift_dict[resnum]
+            if pd.isna(d.get('H_RING', np.nan)):
+                d['H_RING'] = d.get('1H_RING', np.nan)
+            if pd.isna(d.get('HA_RING', np.nan)):
+                d['HA_RING'] = d.get('1HA_RING', np.nan)
 
         return res_ring_shift_dict
 
     def NH_O_bond(self, nn_tree, res_obj, im1_atoms, ip1_atoms, rad, atom0, atom1, at_type, efilt=False):
         res_i_atoms = list(res_obj.get_atoms())
-        angle2 = 0.0
-        angle1 = 0.0
+        angle2 = angle1 = 0.0
         excl_at = []
-        while (angle2 < (math.pi / 2)) or (angle1 < (math.pi / 2)):
-            if atom1.element == 'O': # Finding hydrogen bond for carboxyl oxygen
-                full_excl = res_i_atoms + ip1_atoms + excl_at
-            else: # Finding hydrogen bond for amide hydrogen
-                full_excl = res_i_atoms + im1_atoms + excl_at
+        while angle2 < math.pi / 2 or angle1 < math.pi / 2:
+            full_excl = (res_i_atoms + ip1_atoms + excl_at
+                         if atom1.element == 'O'
+                         else res_i_atoms + im1_atoms + excl_at)
             atom2 = self.find_nearest_atom(nn_tree, atom1, rad, atom_type=at_type, excl=full_excl)
             if atom2 is None:
-                return 5*[0] #If there are no atoms of the specified type within rad of atom1 and accounting for exclusions, then return list of zeros for HNbond_params
-            excl_at += [atom2]
+                return [0] * 5
+            excl_at.append(atom2)
             angle2 = PDB.calc_angle(atom0.get_vector(), atom1.get_vector(), atom2.get_vector())
             bond_dist = atom1 - atom2
-#            Natom = res_obj['N']
-#            HNangle2 = PDB.calc_angle(Natom.get_vector(), HNatom.get_vector(), HNOatom.get_vector())
             parent_tree = PDB.NeighborSearch(list(atom2.get_parent().get_atoms()))
             try:
                 atom3 = self.find_nearest_atom(parent_tree, atom2, rad, atom_type=['N', 'C', 'O'])
-                #HNOCatom = HNOatom.get_parent()['C']
                 angle1 = PDB.calc_angle(atom1.get_vector(), atom2.get_vector(), atom3.get_vector())
-                energy = 0.084 * 332 * (1/(atom0 - atom2) + 1/(atom1 - atom3) - 1/(bond_dist) - 1/(atom0 - atom3))
+                energy = 0.084 * 332 * (
+                    1 / (atom0 - atom2) + 1 / (atom1 - atom3) - 1 / bond_dist - 1 / (atom0 - atom3)
+                )
             except AttributeError:
-                angle1 = math.pi * 109.5 /180
-                energy = 0
-                if angle2 >= math.pi /2:
-                    return [bond_dist, math.cos(angle1), math.cos(angle2), 1, energy] # Return the parameter list first so that it will not go through energy check
-            HNbond_params = [bond_dist, math.cos(angle1), math.cos(angle2), 1, energy]
-            if efilt and energy > -0.5: 
-                angle1 = 0.0 #If filtering by energy, reset one of the angles so that the while condition is not met and the loop will try again with a new atom2 if any candidates remain
-                
-        return HNbond_params
+                angle1 = math.pi * 109.5 / 180
+                energy = 0.0
+                if angle2 >= math.pi / 2:
+                    return [bond_dist, math.cos(angle1), math.cos(angle2), 1, energy]
+            if efilt and energy > -0.5:
+                angle1 = 0.0
+        return [bond_dist, math.cos(angle1), math.cos(angle2), 1, energy]
 
+    def hbond_network(self, nn_tree, res_obj, rad=None, ha_bond='restrictive', efilt=False, efilter_O2=True):
+        if rad is None:
+            rad = [5.0, 5.0, 5.0]
+        HAbond_Params = [0] * 5
+        HNbond_Params = [0] * 5
+        Obond_Params = [0] * 5
 
-    def hbond_network(self, nn_tree, res_obj, rad=3*[5.0], ha_bond='restrictive', efilt=False, efilter_O2=True):
-        '''
-        Constructs parameters that encode the structure of 3 different Hydrogen bonds that may occur on a given residue. Each possible hydrogen bond is described by 4 parameters: The first is the distance from donor hydrogen to acceptor atom dHA. The second and third numbers are the cosines of the bond angle at the acceptor atom and the donor hydrogen respecctively. The final number is a boolean for the existence of the H-bond. The parameters are returned as a single list in the following order: alpha Hydrogen, Nitrogen Hydrogen, Oxygen.
-        
-        Args:
-            nn_tree - A tree containing the distances between atoms in the set of interest (Bio.PDB.NeighborSearch)
-            res_obj - Residue for which we wish to find the Hydrogen bond parameters (Bio.PDB.Residue)
-            rad - The distance within which to search for each of the three types of bonds H_alpha, H_N, and O (List of Float)
-            ha_bond - If restrictive, use definition from Sparta+ (definition given in the Wagner, Pardi, Wuthrich article).  If permissive, use a straight geometric definition (Str)
-            efilter_O2 - When ha_bond == 'restrictive', use the DSSP energy of the secondary hydrogen bond to the Oxygen in question as a cutoff (Bool)
-
-        Returns:
-            output - A sum of lists [dHA, Cos(phi), Cos(psi), 1] containing the bond parameters or [0, 0, 0, 0] for each of 3 possible Hydrogen bonds. The order of parameters is alpha Hydrogen, Nitrogen Hydrogen, Oxygen (List of Float)
-        '''
-
-        # First initialize all bonds as nonexistent
-        HAbond_Params = [0]*5
-        HNbond_Params = [0]*5
-        Obond_Params = [0]*5
-
-        # Define atoms
-        for at in ['HA', '1HA']:
-            try:
-                HAatom = res_obj[at]
-                break
-            except KeyError:
-                HAatom = None
-        for at in ['H', '1H', 'H1', 'D', '1D', 'D1']:
-            try:
-                HNatom = res_obj[at]
-                break
-            except KeyError:
-                HNatom = None
-        try:
-            Oatom = res_obj['O']
-        except KeyError:
-            Oatom = None
+        HAatom = next((res_obj[at] for at in ['HA', '1HA'] if at in res_obj), None)
+        HNatom = next((res_obj[at] for at in ['H', '1H', 'H1', 'D', '1D', 'D1'] if at in res_obj), None)
+        Oatom = res_obj['O'] if 'O' in res_obj else None
 
         res_i_atoms = list(res_obj.get_atoms())
         all_res = list(res_obj.get_parent().get_parent().get_residues())
         idx_i = all_res.index(res_obj)
-        try:
-            res_ip1 = all_res[idx_i + 1]
-            if res_obj.get_full_id()[2] == res_ip1.get_full_id()[2]:
-                ip1_atoms = list(res_ip1.get_atoms())
-            else:
-                res_ip1 = None
-                ip1_atoms = []
-        except IndexError:
-            res_ip1 = None
-            ip1_atoms = []
-        try:
-            res_im1 = all_res[idx_i - 1]
-            if res_obj.get_full_id()[2] == res_im1.get_full_id()[2]:
-                im1_atoms = list(res_im1.get_atoms())
-            else:
-                res_im1 = None
-                im1_atoms = []
-        except IndexError:
-            res_im1 = None
-            im1_atoms = []
-        # Use the above-defined functions to find the nearest Hydrogen/Oxygen to each atom
-        # We only search within rad so if we get None, there is no H-bond.
-        if HAatom is None:
-            HAOatom = None
-        else:
+
+        def _get_neighbor_atoms(idx):
+            try:
+                nbr = all_res[idx]
+                if res_obj.get_full_id()[2] == nbr.get_full_id()[2]:
+                    return nbr, list(nbr.get_atoms())
+            except IndexError:
+                pass
+            return None, []
+
+        res_ip1, ip1_atoms = _get_neighbor_atoms(idx_i + 1)
+        res_im1, im1_atoms = _get_neighbor_atoms(idx_i - 1)
+
+        if HAatom is not None:
             ACatom = res_obj['CA']
             if ha_bond == 'permissive':
                 HAOatom = self.find_nearest_atom(nn_tree, HAatom, rad[0], atom_type=['N', 'O'], excl=res_i_atoms)
-                if HAOatom is None:
-                    pass
-                else:
+                if HAOatom is not None:
                     HAangle2 = PDB.calc_angle(ACatom.get_vector(), HAatom.get_vector(), HAOatom.get_vector())
                     HAbond_dist = HAatom - HAOatom
                     try:
                         HAOCatom = HAOatom.get_parent()['C']
+                        HAangle1 = PDB.calc_angle(HAatom.get_vector(), HAOatom.get_vector(), HAOCatom.get_vector())
+                        HAenergy = 0.084 * 332 * (
+                            1 / (ACatom - HAOatom) + 1 / (HAatom - HAOCatom) - 1 / HAbond_dist - 1 / (ACatom - HAOCatom)
+                        )
+                        flag = 1
                     except KeyError:
-                        HAOCatom = None
-                    if HAOCatom is None: #This should indicate that the Oxygen in question is in a water molecule
-                        HAangle1 = math.pi * 109.5 /180 # Assume the water oxygen is in optimal geometry
-                        HAenergy = 0
+                        HAangle1 = math.pi * 109.5 / 180
+                        HAenergy = 0.0
                         flag = 1
                     HAbond_Params = [HAbond_dist, math.cos(HAangle1), math.cos(HAangle2), flag, HAenergy]
-                    
             elif ha_bond == 'restrictive':
-                excl_at_Ha = [] # A list of possible acceptor atoms that have been returned by nearest atom searches but that failed for some other reason so should be excluded from future searches
-                flag = 0
-                HAangle2 = 0
-                HAangle1 = 0
-                while (HAangle2 < (math.pi / 2)) or (HAangle1 < (math.pi / 2)):
-                    flag=0
+                excl_at_Ha: list = []
+                flag = HAangle2 = HAangle1 = 0
+                while HAangle2 < math.pi / 2 or HAangle1 < math.pi / 2:
+                    flag = 0
                     full_excl = res_i_atoms + ip1_atoms + im1_atoms + excl_at_Ha
                     HAOatom = self.find_nearest_atom(nn_tree, HAatom, rad[0], atom_type='O', excl=full_excl)
-                    if HAOatom is None: # No possible HA bond so break loop leaving HAbond_Params as 5*[0]
-                        HAbond_Params=[0]*5
+                    if HAOatom is None:
+                        HAbond_Params = [0] * 5
                         break
-                    else:
-                        excl_at_Ha += [HAOatom] # Add this acceptor to the exclusion list so that if we redo the loop it will not be included in the search again
-                        HAangle2 = PDB.calc_angle(ACatom.get_vector(), HAatom.get_vector(), HAOatom.get_vector())
-                        HAbond_dist = HAatom - HAOatom
-                        try:
-                            HAOCatom = HAOatom.get_parent()['C']
-                        except KeyError:
-                            HAOCatom = None
-                        if HAOCatom is None: #This should indicate that the Oxygen in question is in a water molecule so set angle and energy to some default values but keep the HA bond
-                            HAangle1 = math.pi * 109.5 /180
-                            HAenergy = 0
-                            flag = 1
-                        else:
-                            HAangle1 = PDB.calc_angle(HAatom.get_vector(), HAOatom.get_vector(), HAOCatom.get_vector())
-                            HAenergy = 0.084 * 332 * (1/(ACatom - HAOatom) + 1/(HAatom - HAOCatom) - 1/(HAbond_dist) - 1/(ACatom - HAOCatom))
-                            O_idx = all_res.index(HAOatom.get_parent()) # Get index of acceptor Oxygen in list of residues so we can exclude the correct neighbor residue when we check if this Oxygen has a secondary H-bond
-                            try:
-                                O_ip1_res = all_res[O_idx + 1]
-                                O_ip1_atoms = list(O_ip1_res.get_atoms())
-                            except IndexError:
-                                O_ip1_atoms = []
-                            O_ip1_atoms += [HAatom] #Need to exclude the H-alpha atom from the neighbor search but can't exclude all atoms on res_obj since the secondary H-bond on the Oxygen could be to the HN on res_obj
-                            secondary_O_params = self.NH_O_bond(nn_tree, HAOatom.get_parent(), [], O_ip1_atoms, rad[2], HAOCatom, HAOatom, ['H', 'D'], efilt=efilter_O2) # Look for H-bond on acceptor Oxygen
-                            if secondary_O_params[-2] == 1: # If acceptor Oxygen has an H-bond, keep candidate HA H-bond else loop will be repeated
-                               flag = 1
-                        HAbond_Params = [HAbond_dist, math.cos(HAangle1), math.cos(HAangle2), flag, HAenergy]             
+                    excl_at_Ha.append(HAOatom)
+                    HAangle2 = PDB.calc_angle(ACatom.get_vector(), HAatom.get_vector(), HAOatom.get_vector())
+                    HAbond_dist = HAatom - HAOatom
+                    try:
+                        HAOCatom = HAOatom.get_parent()['C']
+                        HAangle1 = PDB.calc_angle(HAatom.get_vector(), HAOatom.get_vector(), HAOCatom.get_vector())
+                        HAenergy = 0.084 * 332 * (
+                            1 / (ACatom - HAOatom) + 1 / (HAatom - HAOCatom) - 1 / HAbond_dist - 1 / (ACatom - HAOCatom)
+                        )
+                        O_idx = all_res.index(HAOatom.get_parent())
+                        _, O_ip1_atoms = _get_neighbor_atoms(O_idx + 1)
+                        O_ip1_atoms += [HAatom]
+                        sec = self.NH_O_bond(nn_tree, HAOatom.get_parent(), [], O_ip1_atoms, rad[2],
+                                             HAOCatom, HAOatom, ['H', 'D'], efilt=efilter_O2)
+                        flag = sec[-2]
+                    except KeyError:
+                        HAangle1 = math.pi * 109.5 / 180
+                        HAenergy = 0.0
+                        flag = 1
+                    HAbond_Params = [HAbond_dist, math.cos(HAangle1), math.cos(HAangle2), flag, HAenergy]
 
-        if HNatom is None:
-            pass
-        else:
+        if HNatom is not None:
             Natom = res_obj['N']
-            HNbond_Params = self.NH_O_bond(nn_tree, res_obj, im1_atoms, ip1_atoms, rad[1], Natom, HNatom, ['N', 'O'], efilt=efilt)
-        if Oatom is None:
-            pass
-        else:
+            HNbond_Params = self.NH_O_bond(nn_tree, res_obj, im1_atoms, ip1_atoms, rad[1],
+                                            Natom, HNatom, ['N', 'O'], efilt=efilt)
+        if Oatom is not None:
             Catom = res_obj['C']
-            Obond_Params = self.NH_O_bond(nn_tree, res_obj, im1_atoms, ip1_atoms, rad[2], Catom, Oatom, ['H', 'D'], efilt=efilt)
-        output = HAbond_Params + HNbond_Params + Obond_Params
-        return output
+            Obond_Params = self.NH_O_bond(nn_tree, res_obj, im1_atoms, ip1_atoms, rad[2],
+                                           Catom, Oatom, ['H', 'D'], efilt=efilt)
+        return HAbond_Params + HNbond_Params + Obond_Params
 
-    def check_disulfide(self, nn_tree, res_obj):
-        '''
-        Find out the oxidation state of the cysdiene residue of interest. i.e. determing whether the cysdiene forms a disulfide bond with other residues
-
-        args:
-            nn_tree - A tree containing the distances between atoms in the set of interest (Bio.PDB.NeighborSearch)
-            res_obj - A CYS residue that we want to find out the oxidation state (Bio.PDB.Residue)
-
-        returns:
-            Bool - whether the CYS residue is oxidized or not
-        '''
-        try:
-            S_atom = res_obj["SG"]
-        except KeyError:
-            S_atom = None
-            for atom in res_obj.child_list:
-                if 'S' in atom.name:
-                    S_atom = atom
-                    break
-            if S_atom is None:
-                return False
+    def check_disulfide(self, nn_tree, res_obj) -> bool:
+        S_atom = res_obj.get('SG', None)
+        if S_atom is None:
+            S_atom = next((a for a in res_obj.child_list if 'S' in a.name), None)
+        if S_atom is None:
+            return False
         nn_S = self.find_nearest_atom(nn_tree, S_atom, 2.5, atom_type='S')
         if nn_S is None:
             return False
-        else:
-            # Check whether the atom occurs in a residue more than 4 amino acid away
-            second_S_res_id = nn_S.parent.id[1]
-            if abs(second_S_res_id - res_obj.id[1]) >= 4:
-                return True
-            return False 
+        return abs(nn_S.parent.id[1] - res_obj.id[1]) >= 4
 
+    # ── Single-residue feature extraction ────────────────────────────────────
 
-    def df_from_file_1res(self, fpath, hbrad=3*[5.0], ha_bond='restrictive', efilt=False, efilter_O2=True, s2rad=10.0, hse=True, first_chain_only=False, bfact_mode='all', sequence_columns=0):
-
-        '''Function to create a pandas DataFrame of single-residue SPARTA+ features from a given PDB file.
-
-        Args:
-            fpath - path to PDB file (Str)
-            hbrad - max length of hydrogen bonds (Float)
-            ha_bond - restrictive or permissive, see hbond_network function (Str)
-            efilt - use DSSP energy as cutoff for H-bonds, see hbond_network function (Bool)
-            efilter_O2 - see hbond_network function (Bool)
-            s2rad - distance within which to include heavy atoms for modeling S2 parameter (Float)
-            hse - include a feature column for the half-sphere exposure (Bool)
-            first_chain_only - only extract the first chain in the model (Bool)
-            bfact_mode - Identifies the set of atoms used to obtain an average b-factor for a given residue.  Accepts "all" or "set6".  See get_bfactor (Str)
-            sequence_columns - number of flanking residues on either side of the central residue to include for sequence matching columns (Int)
-
-        Returns:
-            df - DataFrame with number of rows equal to number of standard amino acids in the PDB and columns given by the SPARTA+ features as well as some preliminary file and residue ID info and additional features beyond the SPARTA+ set (Pandas DataFrame)
-            '''
+    def df_from_file_1res(
+        self,
+        fpath: str,
+        hbrad=None,
+        ha_bond: str = 'restrictive',
+        efilt: bool = False,
+        efilter_O2: bool = True,
+        s2rad: float = 10.0,
+        hse: bool = True,
+        first_chain_only: bool = False,
+        bfact_mode: str = 'all',
+        sequence_columns: int = 0,
+    ) -> pd.DataFrame:
+        if hbrad is None:
+            hbrad = [5.0, 5.0, 5.0]
 
         parser = PDBParser(PERMISSIVE=1)
         structure = parser.get_structure('structure', fpath)
-        if "H" not in set((atom.get_name() for atom in structure.get_atoms())):
-            print("Warning! No hydrogen atoms found in the structure. Using a structure without hydrogen atoms will significantly detoriate the performance!!!")
+        if "H" not in {atom.get_name() for atom in structure.get_atoms()}:
+            print("Warning! No hydrogen atoms found — predictions may be degraded.")
+
         file_id = fpath.split('/')[-1].split('.')[0].split('_')[0]
         file_name = fpath.split('/')[-1]
+        AAlet3 = sorted(_THREE_TO_ONE.keys())
 
         col_names = ['FILE_ID', 'PDB_FILE_NAME', 'RESNAME', 'RES_NUM', 'CHAIN']
-        col_names +=[i+j for i in ['PHI_', 'PSI_'] for j in ['COS', 'SIN']]
-        col_names += [i+j for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-        col_names += [i+j for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
+        col_names += [i + j for i in ['PHI_', 'PSI_'] for j in ['COS', 'SIN']]
+        col_names += [i + j for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+        col_names += [i + j for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
         col_names += ['S2']
-        AAlet3 = [i.upper() for i in sorted(IUPACData.protein_letters_3to1.keys())]
-        col_names += ['BLOSUM62_NUM_'+AAlet3[i] for i in range(20)]
+        col_names += [f'BLOSUM62_NUM_{AAlet3[i]}' for i in range(20)]
         if hse:
-            col_names += ['HSE_CA' + i  for i in ['_U', '_D', '_Angle']]
+            col_names += ['HSE_CA' + i for i in ['_U', '_D', '_Angle']]
             col_names += ['HSE_CB' + i for i in ['_U', '_D']]
-        col_names += ['A_HELIX_SS', 'B_BRIDGE_SS', 'STRAND_SS', '3_10_HELIX_SS', 'PI_HELIX_SS', 'TURN_SS', 'BEND_SS', 'NONE_SS']
-        col_names += ['REL_ASA', 'ABS_ASA']
-        col_names += ['DSSP_PHI', 'DSSP_PSI']
-        col_names += ['NH-O1_ENERGY', 'NH-O2_ENERGY', 'O-NH1_ENERGY', 'O-NH2_ENERGY']
+        col_names += ['A_HELIX_SS', 'B_BRIDGE_SS', 'STRAND_SS', '3_10_HELIX_SS', 'PI_HELIX_SS',
+                      'TURN_SS', 'BEND_SS', 'NONE_SS', 'REL_ASA', 'ABS_ASA', 'DSSP_PHI', 'DSSP_PSI',
+                      'NH-O1_ENERGY', 'NH-O2_ENERGY', 'O-NH1_ENERGY', 'O-NH2_ENERGY']
         ring_column_names = ['C_RING', 'CA_RING', 'CB_RING', 'N_RING', 'H_RING', 'HA_RING', 'HA2_RING', 'HA3_RING']
-        col_bfact = ['AVG_B']
-        col_names += ring_column_names
-        col_names += col_bfact
+        col_names += ring_column_names + ['AVG_B']
         if sequence_columns > 0:
-            seq_match_cols = ['RESNAME_i-' + str(i) for i in range(sequence_columns, 0, -1)] + ['RESNAME_i+' + str(i) for i in range(1, sequence_columns+1)]
+            seq_match_cols = (
+                [f'RESNAME_i-{i}' for i in range(sequence_columns, 0, -1)]
+                + [f'RESNAME_i+{i}' for i in range(1, sequence_columns + 1)]
+            )
             col_names += seq_match_cols
         col_names += ["CYS_OX"]
+
         data = []
         for model in structure:
             nn_tree = PDB.NeighborSearch(list(model.get_atoms()))
             try:
                 dssp = PDB.DSSP(model, fpath)
-            except:
+            except Exception:
                 dssp = []
             if hse:
                 hseca_calc = PDB.HSExposureCA(model)
                 hsecb_calc = PDB.HSExposureCB(model)
 
-            for chain in model: 
+            for chain in model:
                 if sequence_columns > 0:
-                    res_dict = {res.get_id() : idx for idx,res in enumerate(chain.get_unpacked_list())}
-                    list_of_resnames = [res.resname for res in chain.get_unpacked_list()]
-                    list_of_resnames = ['NONE'] * sequence_columns + list_of_resnames + ['NONE'] * sequence_columns
+                    res_dict = {res.get_id(): idx for idx, res in enumerate(chain.get_unpacked_list())}
+                    list_of_resnames = (
+                        ['NONE'] * sequence_columns
+                        + [res.resname for res in chain.get_unpacked_list()]
+                        + ['NONE'] * sequence_columns
+                    )
                 dihedrals = self.calc_phi_psi(chain)
                 polys = PDB.PPBuilder(radius=2.1).build_peptides(chain)
-#                poly_residues = [j for i in polys for j in i]
-#                insertion_resnums = []
-#                #remove residues with insertion codes from poly residues.
-#                for poly_res in poly_residues:
-#                    if poly_res.get_full_id()[3][2] != ' ':
-#                        insertion_resnums += [poly_res.get_full_id()[3][1]]
-#                poly_residues = [i for i in poly_residues if i.get_full_id()[3][1] not in insertion_resnums]
                 poly_residues = [res for poly in polys for res in poly if res.id[2] == ' ']
-                seq = ''.join([PDB.Polypeptide.three_to_one(i.get_resname()) for i in poly_residues])
-                chain_resnum_list = [i.get_id()[1] for i in poly_residues]
+                seq = ''.join(_three_to_one(r.get_resname()) for r in poly_residues)
+                chain_resnum_list = [r.get_id()[1] for r in poly_residues]
                 rings = self.calc_ring_currents(poly_residues)
+
                 for l, res in enumerate(poly_residues):
                     resname = self._fix_res_name(res.resname)
-
-                    #A few defensive checks to make sure we are looping through peptide segments correctly
                     if resname not in AAlet3:
-                        raise Exception('Something is wrong with peptide loop: '+fpath)
-                    if PDB.Polypeptide.three_to_one(resname)!=seq[l]:
-                        raise Exception('Something is wrong with peptide loop: '+fpath)
+                        raise ValueError(f'Unexpected residue in peptide loop: {fpath}')
+                    if _three_to_one(resname) != seq[l]:
+                        raise ValueError(f'Peptide loop inconsistency: {fpath}')
 
                     res_id = res.get_id()
                     resnum = res_id[1]
                     row_data = [file_id, file_name, resname, resnum, chain.get_id()]
                     row_data += dihedrals[l]
-                    torsions = self.calc_torsion_angles(res)
-                    row_data += torsions
-                    HBonds = self.hbond_network(nn_tree, res, hbrad, ha_bond=ha_bond, efilt=efilt, efilter_O2=efilter_O2)
-                    row_data += HBonds
+                    row_data += self.calc_torsion_angles(res)
+                    row_data += self.hbond_network(nn_tree, res, hbrad, ha_bond=ha_bond,
+                                                    efilt=efilt, efilter_O2=efilter_O2)
                     row_data += [self.s2_param(nn_tree, res, chain, s2rad)]
                     row_data += self.blosum_nums(res)
                     if hse:
                         try:
-                            hseca = hseca_calc[(chain.get_id(), res_id)]
-                            hseca = list(hseca)
-                            hsecb = hsecb_calc[(chain.get_id(), res_id)]
-                            hsecb = list(hsecb)[:-1]
+                            hseca = list(hseca_calc[(chain.get_id(), res_id)])
+                            hsecb = list(hsecb_calc[(chain.get_id(), res_id)])[:-1]
                         except KeyError:
-                            hseca = 3 * [0]
-                            hsecb = 2 * [0]
-                        row_data += hseca
-                        row_data += hsecb
+                            hseca, hsecb = [0] * 3, [0] * 2
+                        row_data += hseca + hsecb
                     try:
                         dssp_dat = dssp[(chain.id, res.id)]
                         row_data += secondary_struc_dict[dssp_dat[2]]
@@ -1060,76 +642,73 @@ class PDB_SPARTAp_DataReader(BaseDataReader):
                         row_data += [dssp_dat[4], dssp_dat[5]]
                         row_data += [dssp_dat[7], dssp_dat[9], dssp_dat[11], dssp_dat[13]]
                     except KeyError:
-                        print('KeyError at ' + str((chain.id, res.id)) + '.  Skipping this residue')
-                        row_data += 16*[0]
+                        print(f'KeyError at {(chain.id, res.id)} — skipping residue')
+                        row_data += [0] * 16
                         continue
                     except TypeError:
-                        print('DSSP failed on ' + str((chain.id, res.id)) + '.  Skipping this residue')
-                        row_data += 16*[0]
+                        print(f'DSSP failed at {(chain.id, res.id)} — skipping residue')
+                        row_data += [0] * 16
                         continue
                     row_data += [rings[resnum][i] for i in ring_column_names]
                     row_data += [self.get_bfactor(res, atoms=bfact_mode)]
-                    
                     if sequence_columns > 0:
-                        central_res_idx = res_dict[res.get_id()] + sequence_columns # Obtain index of central residue, accounting for the 'NONE' padding of list_of_resnames
-                        row_data += list_of_resnames[central_res_idx - sequence_columns : central_res_idx] + list_of_resnames[central_res_idx+1 : central_res_idx + 1 + sequence_columns]
-                    if resname == "CYS":
-                        # Check oxidation state of cysdiene (whether there are disulfide bonds)
-                        row_data += [self.check_disulfide(nn_tree, res)]
-                    else:
-                        row_data += [False]
+                        central = res_dict[res.get_id()] + sequence_columns
+                        row_data += (
+                            list_of_resnames[central - sequence_columns: central]
+                            + list_of_resnames[central + 1: central + 1 + sequence_columns]
+                        )
+                    row_data += [self.check_disulfide(nn_tree, res) if resname == "CYS" else False]
                     data.append(row_data)
+
                 if first_chain_only:
                     break
-        df = pd.DataFrame(data, columns=col_names)
-        return df
 
+        return pd.DataFrame(data, columns=col_names)
 
-    def df_from_file_3res(self, fpath, hbrad=3*[5.0], ha_bond='restrictive', efilt=False, efilter_O2=True, s2rad=10.0, rcshifts=True, hse=True, first_chain_only=False, bfact_mode='all', sequence_columns=0):
+    # ── Three-residue (tripeptide) feature extraction ─────────────────────────
 
-        '''Function to create a pandas DataFrame of SPARTA+ features from a given PDB file.
+    def df_from_file_3res(
+        self,
+        fpath: str,
+        hbrad=None,
+        ha_bond: str = 'restrictive',
+        efilt: bool = False,
+        efilter_O2: bool = True,
+        s2rad: float = 10.0,
+        rcshifts: bool = True,
+        hse: bool = True,
+        first_chain_only: bool = False,
+        bfact_mode: str = 'all',
+        sequence_columns: int = 0,
+    ) -> pd.DataFrame:
+        if hbrad is None:
+            hbrad = [5.0, 5.0, 5.0]
 
-        Args:
-            fpath - Path to PDB file (Str)
-            hbrad - Max length of hydrogen bonds (Float)
-            s2rad - Distance within which to include heavy atoms for modeling S2 parameter (Float)
-            rcshifts - Include a column for random coil chemical shifts (Bool)
-            hse - include a feature column for the half-sphere exposure (Bool)
-            first_chain_only - only extract the first chain in the model (Bool)
-            bfact_mode - Identifies the set of atoms used to obtain an average b-factor for a given residue.  Accepts "all" or "set6".  See get_bfactor (Str)
-            sequence_columns - number of flanking residues on either side of the central residue to include for sequence matching columns (Int)
-
-        Returns:
-            df - DataFrame with number of rows equal to number of standard amino acids in the PDB and columns given by the SPARTA+ features as well as some preliminary file and residue ID info and additional features beyond the SPARTA+ set (Pandas DataFrame)
-        '''
-
-        #Names of columns from single-residue DataFrame for easier access
-        phipsi_names = [i+j for i in ['PHI_', 'PSI_'] for j in ['COS', 'SIN']]
-        chi_names = [i+j for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-        hbprev_names = ['O_'+j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
-        hb_names = [i+j for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
-        hbnext_names = ['HN_'+j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
-        hse_names = ['HSE_CA' + i  for i in ['_U', '_D', '_Angle']]
-        hse_names += ['HSE_CB' + i for i in ['_U', '_D']]
-        ss_names = ['A_HELIX_SS', 'B_BRIDGE_SS', 'STRAND_SS', '3_10_HELIX_SS', 'PI_HELIX_SS', 'TURN_SS', 'BEND_SS', 'NONE_SS']
+        phipsi_names = [i + j for i in ['PHI_', 'PSI_'] for j in ['COS', 'SIN']]
+        chi_names = [i + j for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+        hbprev_names = ['O_' + j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
+        hb_names = [i + j for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
+        hbnext_names = ['HN_' + j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS', 'ENERGY']]
+        hse_names = ['HSE_CA' + i for i in ['_U', '_D', '_Angle']] + ['HSE_CB' + i for i in ['_U', '_D']]
+        ss_names = ['A_HELIX_SS', 'B_BRIDGE_SS', 'STRAND_SS', '3_10_HELIX_SS', 'PI_HELIX_SS',
+                    'TURN_SS', 'BEND_SS', 'NONE_SS']
         asa_names = ['REL_ASA', 'ABS_ASA']
         dssp_phipsi_names = ['DSSP_PHI', 'DSSP_PSI']
         dssp_hbond_names = ['NH-O1_ENERGY', 'NH-O2_ENERGY', 'O-NH1_ENERGY', 'O-NH2_ENERGY']
         dssp_names = asa_names + ss_names + dssp_hbond_names + dssp_phipsi_names
 
-        # Define column names for new DataFrame
+        AAlet3 = sorted(_THREE_TO_ONE.keys())
+        blosum_names_local = [f'BLOSUM62_NUM_{AAlet3[i]}' for i in range(20)]
+
         col_id = ['FILE_ID', 'PDB_FILE_NAME', 'RESNAME', 'RES_NUM', 'CHAIN']
         col_extra_resnames = ['RESNAME_im1', 'RESNAME_ip1']
-        col_phipsi = [i+j+k for k in ['i-1', 'i', 'i+1'] for i in ['PHI_', 'PSI_'] for j in ['COS_', 'SIN_']]
-        #col_phipsi += [i+j for i in ['PHI_', 'PSI_'] for j in ['COS_i', 'SIN_i']]
-        #col_phipsi += [i+j for i in ['PHI_', 'PSI_'] for j in ['COS_i+1', 'SIN_i+1']]
-        col_chi = [i+j+k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-        col_hbprev = ['O_'+i+'_i-1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
-        col_hbond = [i+j+'_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
-        col_hbnext = ['HN_'+i+'_i+1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
-        col_s2 = ['S2'+i for i in ['_i-1', '_i', '_i+1']]
-        blosum_names = ['BLOSUM62_NUM_'+sorted(list(IUPACData.protein_letters_3to1.keys()))[i].upper() for i in range(20)]
-        col_blosum = [blosum_names[i]+j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
+        col_phipsi = [i + j + k for k in ['i-1', 'i', 'i+1'] for i in ['PHI_', 'PSI_'] for j in ['COS_', 'SIN_']]
+        col_chi = [i + j + k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
+        col_hbprev = ['O_' + i + '_i-1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
+        col_hbond = [i + j + '_i' for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
+        col_hbnext = ['HN_' + i + '_i+1' for i in ['d_HA', '_COS_H', '_COS_A', '_EXISTS', '_ENERGY']]
+        col_s2 = ['S2' + i for i in ['_i-1', '_i', '_i+1']]
+        col_blosum = [blosum_names_local[i] + j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
         col_names = col_id + col_extra_resnames + col_phipsi + col_chi + col_hbprev + col_hbond + col_hbnext + col_s2 + col_blosum
         if rcshifts:
             col_rccs = ['RC_' + i for i in atom_names]
@@ -1144,228 +723,111 @@ class PDB_SPARTAp_DataReader(BaseDataReader):
         bfact_names = ['AVG_B' + i for i in ['_i-1', '_i', '_i+1']]
         col_names += bfact_names
         if sequence_columns > 0:
-            seq_match_cols = ['RESNAME_i-' + str(i) for i in range(sequence_columns, 0, -1)] + ['RESNAME_i+' + str(i) for i in range(1, sequence_columns+1)]
+            seq_match_cols = (
+                [f'RESNAME_i-{i}' for i in range(sequence_columns, 0, -1)]
+                + [f'RESNAME_i+{i}' for i in range(1, sequence_columns + 1)]
+            )
             col_names += seq_match_cols
 
+        df_1res_all_chains = self.df_from_file_1res(
+            fpath, hbrad, ha_bond=ha_bond, efilt=efilt, efilter_O2=efilter_O2,
+            s2rad=s2rad, hse=hse, first_chain_only=first_chain_only,
+            bfact_mode=bfact_mode, sequence_columns=sequence_columns,
+        )
 
-
-        full_df = pd.DataFrame(columns=col_names)
-
-        # Get SPARTA+ features with single-residue function
-        df_1res_all_chains = self.df_from_file_1res(fpath, hbrad, ha_bond=ha_bond, efilt=efilt, efilter_O2=efilter_O2, s2rad=s2rad, hse=hse, first_chain_only=first_chain_only, bfact_mode=bfact_mode, sequence_columns=sequence_columns)
-
-        for chain in list(set(df_1res_all_chains['CHAIN'].tolist())):
+        chain_dfs: list[pd.DataFrame] = []
+        for chain in sorted(set(df_1res_all_chains['CHAIN'].tolist())):
             df = pd.DataFrame(columns=col_names)
-            df_1res = df_1res_all_chains[df_1res_all_chains['CHAIN']==chain]
-            df_1res.index=range(len(df_1res))
-            #Get list of residues from 1res df to account for chain breaks.
-            #Defensive check for resnum uniqueness and monotonicity
+            df_1res = df_1res_all_chains[df_1res_all_chains['CHAIN'] == chain].copy()
+            df_1res.index = range(len(df_1res))
+
             res_list = df_1res['RES_NUM'].tolist()
             if len(set(res_list)) != len(res_list):
-                raise Exception('residue number list has duplicates: '+fpath)
-            if (np.sort(res_list) != res_list).any():
-                raise Exception('residue number list is not ordered: '+fpath)
+                raise ValueError(f'Duplicate residue numbers in: {fpath}')
+            if (np.sort(res_list) != np.array(res_list)).any():
+                raise ValueError(f'Residue numbers not ordered in: {fpath}')
 
+            rows = []
             for i in range(len(df_1res)):
-
-                # Assign ID columns
-                df.loc[i, col_id] = df_1res.loc[i, col_id].values
-
-                #Get resnumber for residue we are looking at
                 res_i_num = df_1res.loc[i, 'RES_NUM']
+                row: dict = {}
+                for col in col_id:
+                    row[col] = df_1res.loc[i, col]
 
-                # Assign column variables containing data from previous residue in the PDB file
-                if (res_i_num-1) not in res_list:
-                    blosum_prev = [0]*20
-                    psi_prev = [0, 0]
-                    phi_prev = [0, 0]
-                    chi_prev = [0]*6
-                    hb_prev = [0]*5
+                if (res_i_num - 1) not in res_list:
+                    blosum_prev = [0] * 20
+                    psi_prev = phi_prev = [0, 0]
+                    chi_prev = [0] * 6
+                    hb_prev = [0] * 5
                     s2_prev = 0
-                    hse_prev = 5*[0]
+                    hse_prev = [0] * 5
                     resname_prev = ''
-                    dssp_prev = 16*[0]
+                    dssp_prev = [0] * 16
                     bfact_prev = [0]
                 else:
-                    blosum_prev = list(df_1res.loc[i-1, blosum_names].values)
-                    psi_prev = [df_1res.loc[i-1, 'PSI_COS'], df_1res.loc[i-1, 'PSI_SIN']]
-                    phi_prev = [df_1res.loc[i-1, 'PHI_COS'], df_1res.loc[i-1, 'PHI_SIN']]
-                    chi_prev = list(df_1res.loc[i-1, chi_names].values)
-                    hb_prev = list(df_1res.loc[i-1, hbprev_names].values)
-                    s2_prev = df_1res.loc[i-1, 'S2']
+                    blosum_prev = list(df_1res.loc[i - 1, blosum_names_local].values)
+                    psi_prev = [df_1res.loc[i - 1, 'PSI_COS'], df_1res.loc[i - 1, 'PSI_SIN']]
+                    phi_prev = [df_1res.loc[i - 1, 'PHI_COS'], df_1res.loc[i - 1, 'PHI_SIN']]
+                    chi_prev = list(df_1res.loc[i - 1, chi_names].values)
+                    hb_prev = list(df_1res.loc[i - 1, hbprev_names].values)
+                    s2_prev = df_1res.loc[i - 1, 'S2']
                     if hse:
-                        hse_prev = list(df_1res.loc[i-1, hse_names].values)
-                    resname_prev = df_1res.loc[i-1, 'RESNAME']
-                    dssp_prev = list(df_1res.loc[i-1, dssp_names])
-                    bfact_prev = [df_1res.loc[i-1, 'AVG_B']]
+                        hse_prev = list(df_1res.loc[i - 1, hse_names].values)
+                    resname_prev = df_1res.loc[i - 1, 'RESNAME']
+                    dssp_prev = list(df_1res.loc[i - 1, dssp_names])
+                    bfact_prev = [df_1res.loc[i - 1, 'AVG_B']]
 
-                # Assign column variables containing data from next residue in the PDB file
-                if (res_i_num+1) not in res_list:
-                    blosum_next = [0]*20
-                    psi_next = [0, 0]
-                    phi_next = [0, 0]
-                    chi_next = [0]*6
-                    hb_next = [0]*5
+                if (res_i_num + 1) not in res_list:
+                    blosum_next = [0] * 20
+                    psi_next = phi_next = [0, 0]
+                    chi_next = [0] * 6
+                    hb_next = [0] * 5
                     s2_next = 0
-                    hse_next = 5*[0]
-                    if rcshifts:
-                        res_next = 'ALA'
+                    hse_next = [0] * 5
+                    res_next = 'ALA' if rcshifts else None
                     resname_next = ''
-                    dssp_next = 16*[0]
+                    dssp_next = [0] * 16
                     bfact_next = [0]
                 else:
-                    blosum_next = list(df_1res.loc[i+1, blosum_names].values)
-                    psi_next = [df_1res.loc[i+1, 'PSI_COS'], df_1res.loc[i+1, 'PSI_SIN']]
-                    phi_next = [df_1res.loc[i+1, 'PHI_COS'], df_1res.loc[i+1, 'PHI_SIN']]
-                    chi_next = list(df_1res.loc[i+1, chi_names].values)
-                    hb_next = list(df_1res.loc[i+1, hbnext_names].values)
-                    s2_next = df_1res.loc[i+1, 'S2']
+                    blosum_next = list(df_1res.loc[i + 1, blosum_names_local].values)
+                    psi_next = [df_1res.loc[i + 1, 'PSI_COS'], df_1res.loc[i + 1, 'PSI_SIN']]
+                    phi_next = [df_1res.loc[i + 1, 'PHI_COS'], df_1res.loc[i + 1, 'PHI_SIN']]
+                    chi_next = list(df_1res.loc[i + 1, chi_names].values)
+                    hb_next = list(df_1res.loc[i + 1, hbnext_names].values)
+                    s2_next = df_1res.loc[i + 1, 'S2']
                     if hse:
-                        hse_next = list(df_1res.loc[i+1, hse_names].values)
-                    if rcshifts:
-                        res_next = df_1res.loc[i+1, 'RESNAME']
-                    resname_next = df_1res.loc[i+1, 'RESNAME']
-                    dssp_next = list(df_1res.loc[i+1, dssp_names])
-                    bfact_next = [df_1res.loc[i+1, 'AVG_B']]
+                        hse_next = list(df_1res.loc[i + 1, hse_names].values)
+                    res_next = df_1res.loc[i + 1, 'RESNAME'] if rcshifts else None
+                    resname_next = df_1res.loc[i + 1, 'RESNAME']
+                    dssp_next = list(df_1res.loc[i + 1, dssp_names])
+                    bfact_next = [df_1res.loc[i + 1, 'AVG_B']]
 
-                # Insert row into DataFrame
-                df.loc[i, col_extra_resnames] = [resname_prev, resname_next]
-                df.loc[i, col_phipsi] = phi_prev + psi_prev + list(df_1res.loc[i, phipsi_names].values) + phi_next + psi_next
-                df.loc[i, col_chi] = chi_prev + list(df_1res.loc[i, chi_names].values) + chi_next
-                df.loc[i, col_hbprev] = hb_prev
-                df.loc[i, col_hbond] = list(df_1res.loc[i, hb_names].values)
-                df.loc[i, col_hbnext] = hb_next
-                df.loc[i, col_s2] = [s2_prev, df_1res.loc[i, 'S2'], s2_next]
-                df.loc[i, col_blosum] = blosum_prev + list(df_1res.loc[i, blosum_names].values) + blosum_next
+                row.update(dict(zip(col_extra_resnames, [resname_prev, resname_next])))
+                row.update(dict(zip(col_phipsi, phi_prev + psi_prev + list(df_1res.loc[i, phipsi_names].values) + phi_next + psi_next)))
+                row.update(dict(zip(col_chi, chi_prev + list(df_1res.loc[i, chi_names].values) + chi_next)))
+                row.update(dict(zip(col_hbprev, hb_prev)))
+                row.update(dict(zip(col_hbond, list(df_1res.loc[i, hb_names].values))))
+                row.update(dict(zip(col_hbnext, hb_next)))
+                row.update(dict(zip(col_s2, [s2_prev, df_1res.loc[i, 'S2'], s2_next])))
+                row.update(dict(zip(col_blosum, blosum_prev + list(df_1res.loc[i, blosum_names_local].values) + blosum_next)))
                 if rcshifts:
-                    resname = df.loc[i, 'RESNAME']
-                    if res_next == 'PRO':
-                        rccs = [randcoil_pro[j][resname] for j in atom_names]
-                    else:
-                        rccs = [randcoil_ala[j][resname] for j in atom_names]
+                    resname = df_1res.loc[i, 'RESNAME']
+                    rc_table = randcoil_pro if res_next == 'PRO' else randcoil_ala
+                    rccs = [rc_table[j][resname] for j in atom_names]
                     if df_1res.loc[i, 'CYS_OX']:
                         if res_next == 'PRO':
-                            print("Warning! Oxidized cys found preceding PRO!")
-                            # Assume that next residue cannot be proline
-                        for idx,j in enumerate(atom_names):
-                            rccs[idx] += oxidized_cys_correction[j]
-                    df.loc[i, col_rccs] = rccs
+                            print("Warning! Oxidized CYS preceding PRO!")
+                        rccs = [v + oxidized_cys_correction[j] for v, j in zip(rccs, atom_names)]
+                    row.update(dict(zip(col_rccs, rccs)))
                 if hse:
-                    df.loc[i, col_hse] = hse_prev + list(df_1res.loc[i, hse_names].values) + hse_next
-                df.loc[i, ring_column_names] = list(df_1res.loc[i, ring_column_names].values)
-                df.loc[i, col_dssp] = dssp_prev + list(df_1res.loc[i, dssp_names]) + dssp_next
-                df.loc[i, bfact_names] = bfact_prev + [df_1res.loc[i, 'AVG_B']] + bfact_next
+                    row.update(dict(zip(col_hse, hse_prev + list(df_1res.loc[i, hse_names].values) + hse_next)))
+                row.update(dict(zip(ring_column_names, list(df_1res.loc[i, ring_column_names].values))))
+                row.update(dict(zip(col_dssp, dssp_prev + list(df_1res.loc[i, dssp_names]) + dssp_next)))
+                row.update(dict(zip(bfact_names, bfact_prev + [df_1res.loc[i, 'AVG_B']] + bfact_next)))
                 if sequence_columns > 0:
-                    df.loc[i, seq_match_cols] = list(df_1res.loc[i, seq_match_cols])
+                    row.update(dict(zip(seq_match_cols, list(df_1res.loc[i, seq_match_cols]))))
+                rows.append(row)
 
-            full_df = full_df.append(df)
-        return full_df
+            chain_dfs.append(pd.DataFrame(rows, columns=col_names))
 
-
-    def df_from_file_tripeptide(self, fpath, hbrad=5.0, s2rad=10.0, rcshifts=True):
-
-        '''Function to create a pandas DataFrame of full tripeptide SPARTA+ features from a given PDB file.
-
-        Args:
-            fpath - Path to PDB file (Str)
-            hbrad - Max length of hydrogen bonds (Float)
-            s2rad - Distance within which to include heavy atoms for modeling S2 parameter (Float)
-            rcshifts - Include a column for random coil chemical shifts (Bool)
-
-        Returns:
-            df - DataFrame  with number of rows equal to number of standard amino acids in the PDB and columns given by the SPARTA+ features as well as some preliminary file and residue ID info and additional features beyond the SPARTA+ set (Pandas DataFrame)
-        '''
-
-        # Get SPARTA+ features with single-residue function and then define column names
-        df_1res = self.df_from_file_1res(fpath, hbrad, s2rad)
-        col_id = ['FILE_ID', 'PDB_FILE_NAME', 'RESNAME', 'RES_NUM']
-        col_phipsi = [i+j+k for k in ['i-1', 'i', 'i+1'] for i in ['PHI_', 'PSI_'] for j in ['COS_', 'SIN_']]
-        col_chi = [i+j+k for k in ['_i-1', '_i', '_i+1'] for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-        col_hbond = [i+j+k for k in ['_i-1', '_i', '_i+1'] for i in ['Ha_', 'HN_', 'O_']
-                     for j in ['d_HA', '_COS_H', '_COS_A', '_EXISTS']]
-        col_s2 = ['S2'+i for i in ['_i-1', '_i', '_i+1']]
-        blosum_names = ['BLOSUM62_NUM_'+sorted(list(IUPACData.protein_letters_3to1.keys()))[i].upper() for i in range(20)]
-        col_blosum = [blosum_names[i]+j for j in ['_i-1', '_i', '_i+1'] for i in range(20)]
-        col_names = col_id + col_phipsi + col_chi + col_hbond + col_s2 + col_blosum
-        if rcshifts:
-            col_rccs = ['RC_' + i for i in atom_names]
-            col_names += col_rccs
-
-
-        df = pd.DataFrame(columns=col_names)
-
-        #Names of columns from single-residue DataFrame for easier access
-        phipsi_names = [i+j for i in ['PHI_', 'PSI_'] for j in ['COS', 'SIN']]
-        chi_names = [i+j for i in ['CHI1_', 'CHI2_'] for j in ['COS', 'SIN', 'EXISTS']]
-#        hbprev_names = ['O_'+j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS']]
-        hb_names = [i+j for i in ['Ha_', 'HN_', 'O_'] for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS']]
-#        hbnext_names = ['HN_'+j for j in ['d_HA', 'COS_H', 'COS_A', 'EXISTS']]
-
-        for i in range(len(df_1res)):
-            # Assign ID columns
-            df.loc[i, col_id] = df_1res.loc[i, col_id].values
-
-            # Assign column variables containing data from previous residue in the PDB file
-            if i == 0:
-                blosum_prev = [0]*20
-                phipsi_prev= [0]*4
-                chi_prev = [0]*6
-                hb_prev = [0]*12
-                s2_prev = 0
-            else:
-                blosum_prev = list(df_1res.loc[i-1, blosum_names].values)
-                phipsi_prev = [df_1res.loc[i-1, 'PHI_COS'], df_1res.loc[i-1, 'PHI_SIN'], df_1res.loc[i-1, 'PSI_COS'], df_1res.loc[i-1, 'PSI_SIN']]
-                chi_prev = list(df_1res.loc[i-1, chi_names].values)
-                hb_prev = list(df_1res.loc[i-1, hb_names].values)
-                s2_prev = df_1res.loc[i-1, 'S2']
-
-            # Assign column variables containing data from next residue in the PDB file
-            if i == len(df_1res)-1:
-                blosum_next = [0]*20
-                phipsi_next= [0]*4
-                chi_next = [0]*6
-                hb_next = [0]*12
-                s2_next = 0
-                if rcshifts:
-                    res_next = 'ALA'
-            else:
-                blosum_next = list(df_1res.loc[i+1, blosum_names].values)
-                phipsi_next = [df_1res.loc[i+1, 'PHI_COS'], df_1res.loc[i+1, 'PHI_SIN'], df_1res.loc[i+1, 'PSI_COS'], df_1res.loc[i+1, 'PSI_SIN']]
-                chi_next = list(df_1res.loc[i+1, chi_names].values)
-                hb_next = list(df_1res.loc[i+1, hb_names].values)
-                s2_next = df_1res.loc[i+1, 'S2']
-                if rcshifts:
-                    res_next = df_1res.loc[i+1, 'RESNAME']
-
-            # Insert row into DataFrame
-            df.loc[i, col_phipsi] = phipsi_prev + list(df_1res.loc[i, phipsi_names].values) + phipsi_next
-            df.loc[i, col_chi] = chi_prev + list(df_1res.loc[i, chi_names].values) + chi_next
-#            df.loc[i, col_hbprev] = hb_prev
-            df.loc[i, col_hbond] = hb_prev + list(df_1res.loc[i, hb_names].values) + hb_next
-#            df.loc[i, col_hbnext] = hb_next
-            df.loc[i, col_s2] = [s2_prev, df_1res.loc[i, 'S2'], s2_next]
-            df.loc[i, col_blosum] = blosum_prev + list(df_1res.loc[i, blosum_names].values) + blosum_next
-            if rcshifts:
-                resname = df.loc[i, 'RESNAME']
-                if res_next == 'PRO':
-                    rccs = [randcoil_pro[i][resname] for i in atom_names]
-                else:
-                    rccs = [randcoil_ala[i][resname] for i in atom_names]
-                df.loc[i, col_rccs] = rccs
-
-
-        return df
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        return pd.concat(chain_dfs, ignore_index=True) if chain_dfs else pd.DataFrame(columns=col_names)

--- a/toolbox.py
+++ b/toolbox.py
@@ -1,4 +1,9 @@
-from Bio.SeqUtils import IUPACData
+#!/usr/bin/env python3
+
+try:
+    from Bio.Data import IUPACData
+except ImportError:
+    from Bio.SeqUtils import IUPACData  # biopython < 1.80
 from Bio import PDB
 from urllib.request import urlopen
 import pickle
@@ -7,240 +12,230 @@ import re
 import numpy as np
 from numpy import argmin
 import subprocess
-import sys
 import pandas as pd
 from io import StringIO
 import ssl
-import subprocess
+from pathlib import Path
+from typing import Optional, Union
 
-protein_dict={pair[0].upper():pair[1] for pair in IUPACData.protein_letters_3to1.items()}
-protein_dict_reverse={pair[1]:pair[0].upper() for pair in IUPACData.protein_letters_3to1.items()}
+protein_dict = {pair[0].upper(): pair[1] for pair in IUPACData.protein_letters_3to1.items()}
+protein_dict_reverse = {pair[1]: pair[0].upper() for pair in IUPACData.protein_letters_3to1.items()}
 
+ATOMS: list[str] = ["H", "HA", "C", "CA", "CB", "N"]
+rmse = lambda x: np.sqrt(np.square(x).mean())
 
-RULER="0         1         2         3         4         5         6         7         8         9        10        11        12"
-ATOMS=["H","HA","C","CA","CB","N"]
-rmse=lambda x: np.sqrt(np.square(x).mean())
 try:
-    check_result=subprocess.check_output(["which","reduce"])
-except:
-    check_result=""
-REDUCE_STATUS=len(check_result)!=0
+    check_result = subprocess.check_output(["which", "reduce"], stderr=subprocess.DEVNULL)
+except Exception:
+    check_result = b""
+REDUCE_STATUS = len(check_result) != 0
+
 
 class PDBSaver:
-    '''
-    Self-defined function for writing a PDB file from Biopython chain object
-    '''
-    def __init__(self):
-        self.structure=None
+    """Write a PDB file from a Biopython chain object, handling disordered atoms."""
 
-    def set_structure(self,structure):
-        self.structure=structure
+    def __init__(self) -> None:
+        self.structure = None
 
-    def save(self,address):
-        if self.structure==None:
+    def set_structure(self, structure) -> None:
+        self.structure = structure
+
+    def save(self, address: Union[str, Path]) -> None:
+        if self.structure is None:
             raise TypeError("Structure not set!")
-        else:
-            contents=[]
-            atom_counter=0
-            for residue in self.structure.get_residues():
-                for atom in residue.get_atoms():
-                    if atom.is_disordered():
-                        atom=atom.child_dict[sorted(atom.child_dict)[0]]
-                    atom_counter+=1
-                    contents.append("ATOM %6d  %-4s%3s %s%4d%1s   %8.3f%8.3f%8.3f  1.00%6.2f         %3s\n"%(atom_counter,atom.name,residue.resname,self.structure.id,residue.get_id()[1],residue.get_id()[2],atom.coord[0],atom.coord[1],atom.coord[2],atom.bfactor,atom.element))
-            with open(address,"w") as f:
-                f.writelines(contents)
+        contents = []
+        atom_counter = 0
+        for residue in self.structure.get_residues():
+            for atom in residue.get_atoms():
+                if atom.is_disordered():
+                    atom = atom.child_dict[sorted(atom.child_dict)[0]]
+                atom_counter += 1
+                contents.append(
+                    f"ATOM {atom_counter:6d}  {atom.name:<4s}{residue.resname:3s} "
+                    f"{self.structure.id}{residue.get_id()[1]:4d}{residue.get_id()[2]:1s}   "
+                    f"{atom.coord[0]:8.3f}{atom.coord[1]:8.3f}{atom.coord[2]:8.3f}"
+                    f"  1.00{atom.bfactor:6.2f}         {atom.element:>3s}\n"
+                )
+        with open(address, "w") as f:
+            f.writelines(contents)
 
 
-def download_pdb(pdb_id,chain_id=None,destination=None,add_hydrogen=False,residue_whitelist=None):
+def download_pdb(
+    pdb_id: str,
+    chain_id: Optional[str] = None,
+    destination: Optional[str] = None,
+    add_hydrogen: bool = False,
+    residue_whitelist: Optional[list] = None,
+) -> bool:
     ssl._create_default_https_context = ssl._create_unverified_context
     try:
-        data=urlopen("https://files.rcsb.org/download/%s.pdb"%pdb_id)
-    except:
-        print("Cannot download PDB %s"%pdb_id)
+        data = urlopen(f"https://files.rcsb.org/download/{pdb_id}.pdb")
+    except Exception:
+        print(f"Cannot download PDB {pdb_id}")
         return False
-    s=[]
-    for line in data:
-        s.append(line.decode("utf-8"))
+    lines = [line.decode("utf-8") for line in data]
     if destination is None:
-        destination=os.getcwd()+"/"
-    if chain_id=="_":
-        filepath=destination+"%s_.pdb"%pdb_id
-    else:
-        filepath=destination+"%s.pdb"%pdb_id
-    with open(filepath,"w") as f:
-        f.writelines(s)
-    if chain_id not in {None,"_"} or residue_whitelist != None:
-        # Need post process after download
-        parser=PDB.PDBParser()
-        struc=parser.get_structure(pdb_id+chain_id,filepath)
-        if chain_id not in {None,"_"}:
-            # Get single chain PDB
-            if len(struc)>1:
-                print("Multiple structures found for %s, only the first structure is taken."%pdb_id)
-                struc=struc[0]
-            chains=[item for item in struc.get_chains() if item.id==chain_id]
-            if len(chains)!=1:
-                print("Cannot find chain %s for PDB %s"%(chain_id,pdb_id))
+        destination = str(Path.cwd()) + "/"
+    filepath = destination + (f"{pdb_id}_.pdb" if chain_id == "_" else f"{pdb_id}.pdb")
+    with open(filepath, "w") as f:
+        f.writelines(lines)
+    if chain_id not in {None, "_"} or residue_whitelist is not None:
+        parser = PDB.PDBParser(QUIET=True)
+        struc = parser.get_structure(pdb_id + (chain_id or ""), filepath)
+        if chain_id not in {None, "_"}:
+            if len(struc) > 1:
+                print(f"Multiple structures found for {pdb_id}, only the first structure is taken.")
+                struc = struc[0]
+            chains = [item for item in struc.get_chains() if item.id == chain_id]
+            if len(chains) != 1:
+                print(f"Cannot find chain {chain_id} for PDB {pdb_id}")
                 return False
-            else:
-                struc=chains[0]
+            struc = chains[0]
         else:
-            struc=struc[0].child_list[0]
+            struc = struc[0].child_list[0]
         if residue_whitelist:
-            # Save only whitelist residues
-            deletion=[]
-            for residue in struc.child_list:
-                if residue.resname not in residue_whitelist:
-                    deletion.append(residue.id)
+            deletion = [
+                residue.id for residue in struc.child_list
+                if residue.resname not in residue_whitelist
+            ]
             for delete_id in deletion:
                 struc.detach_child(delete_id)
-
-        io=PDBSaver()
+        io = PDBSaver()
         io.set_structure(struc)
         os.remove(filepath)
-        filepath=destination+"%s.pdb"%(pdb_id+chain_id)
+        filepath = destination + f"{pdb_id}{chain_id}.pdb"
         io.save(filepath)
     if add_hydrogen:
-        assert REDUCE_STATUS, "REDUCE is not correctly configured. Please make sure REDUCE is in your path. \nFor more information, please visit http://kinemage.biochem.duke.edu/software/reduce.php"
-        os.system("reduce %s > %s -Quiet"%(filepath,filepath+".H"))
-        os.rename(filepath+".H",filepath)
-    print("PDB %s downloaded to %s"%(pdb_id,filepath))
+        assert REDUCE_STATUS, (
+            "REDUCE is not correctly configured. Please make sure REDUCE is in your path.\n"
+            "For more information, please visit http://kinemage.biochem.duke.edu/software/reduce.php"
+        )
+        os.system(f"reduce {filepath} > {filepath}.H -Quiet")
+        os.rename(f"{filepath}.H", filepath)
+    print(f"PDB {pdb_id} downloaded to {filepath}")
     return True
-    
 
-def fetch_seq(pdb_id,chain_id=None):
-    if chain_id=="_":
-        chain_id="A"
+
+def fetch_seq(pdb_id: str, chain_id: Optional[str] = None) -> Union[str, dict]:
+    if chain_id == "_":
+        chain_id = "A"
     try:
-        data=urlopen("https://www.rcsb.org/pdb/download/viewFastaFiles.do?structureIdList=%s&compressionType=uncompressed"%pdb_id)
-    except:
-        print("Cannot find sequence for PDB",pdb_id)
-    seq=""
-    record_seq=False
-    all_chain=chain_id==None
-    all_chain_record=dict()
+        data = urlopen(
+            f"https://www.rcsb.org/pdb/download/viewFastaFiles.do"
+            f"?structureIdList={pdb_id}&compressionType=uncompressed"
+        )
+    except Exception:
+        print(f"Cannot find sequence for PDB {pdb_id}")
+        return ""
+    seq = ""
+    record_seq = False
+    all_chain = chain_id is None
+    all_chain_record: dict = {}
     for line in data:
-        line=line.decode("utf-8")
-        if len(line.strip())==0:
-            # An empty line
+        line = line.decode("utf-8")
+        if not line.strip():
             continue
         if "<!DOCTYPE html" in line:
-            # Need to find superseded PDB
-            main_page=urlopen("https://www.rcsb.org/structure/removed/"+pdb_id)
-            content=main_page.read().decode("utf-8")
-            supersede=content.split("It has been replaced (superseded) by&nbsp<a href=\"/structure/")[1][:4]
-            print("PDB %s has been superseded by %s"%(pdb_id,supersede))
-            return fetch_seq(supersede,chain_id)
+            main_page = urlopen(f"https://www.rcsb.org/structure/removed/{pdb_id}")
+            content = main_page.read().decode("utf-8")
+            supersede = content.split("It has been replaced (superseded) by&nbsp<a href=\"/structure/")[1][:4]
+            print(f"PDB {pdb_id} has been superseded by {supersede}")
+            return fetch_seq(supersede, chain_id)
         if all_chain:
-            # No chain specified, return all chains in a dictionary
-
-            if line[0]==">":
-                # Start of a new chain
-                if len(seq)!=0:
-                    all_chain_record[chain_id]=seq
-                seq=""
-                chain_id=line.split("|")[0].split(":")[1]
-                continue
+            if line[0] == ">":
+                if seq:
+                    all_chain_record[chain_id] = seq
+                seq = ""
+                chain_id = line.split("|")[0].split(":")[1]
             else:
-                seq=seq+line.strip()
+                seq += line.strip()
         else:
-            # Chain specified, only return that chain
-            if ">%s:%s"%(pdb_id.upper(),chain_id.upper()) in line:
-                # The next line starts the required sequence
-                record_seq=True
-                continue
+            if f">{pdb_id.upper()}:{chain_id.upper()}" in line:
+                record_seq = True
             else:
-                if line[0]==">":
-                    # Start of a chain that we don't need
-                    record_seq=False
-                    if len(seq)!=0:
-                        # Requested chain found and recorded
+                if line[0] == ">":
+                    record_seq = False
+                    if seq:
                         return seq
-                    continue
-                else:
-                    if record_seq:
-                        seq=seq+line.strip()
+                elif record_seq:
+                    seq += line.strip()
     if all_chain:
-        # add the last sequence when no chain is specified
-        all_chain_record[chain_id]=seq
+        all_chain_record[chain_id] = seq
         return all_chain_record
-    else:
-        return seq
+    return seq
 
-def decode_seq(seq,supplementary_dict=None):
-    lookup_dict=protein_dict_reverse
+
+def decode_seq(seq: str, supplementary_dict: Optional[dict] = None) -> Union[str, list]:
+    lookup_dict = dict(protein_dict_reverse)
     if supplementary_dict is not None:
-        for item in supplementary_dict:
-            lookup_dict[item]=supplementary_dict[item]
-    seq=seq.upper()
-    if len(seq)==1:
+        lookup_dict.update(supplementary_dict)
+    seq = seq.upper()
+    if len(seq) == 1:
         return lookup_dict[seq]
-    return [lookup_dict.get(r,"UNK") for r in seq]
+    return [lookup_dict.get(r, "UNK") for r in seq]
 
-def form_seq(arr,supplementary_dict=None):
-    lookup_dict=protein_dict
+
+def form_seq(arr: list, supplementary_dict: Optional[dict] = None) -> str:
+    lookup_dict = dict(protein_dict)
     if supplementary_dict is not None:
-        for item in supplementary_dict:
-            lookup_dict[item]=supplementary_dict[item]
-    return "".join([lookup_dict[r.upper()] for r in arr])
+        lookup_dict.update(supplementary_dict)
+    return "".join(lookup_dict[r.upper()] for r in arr)
 
-def load_pkl(path):
-    with open(path,"rb") as f:
-        obj=pickle.load(f)
-    return obj
 
-def dump_pkl(obj,path):
-    with open(path,"wb") as f:
-        pickle.dump(obj,f)
-    print("Saved",os.getcwd()+"/"+path)
+def load_pkl(path: Union[str, Path]) -> object:
+    with open(path, "rb") as f:
+        return pickle.load(f)
 
-def get_pH(shift_file_path,default=5):
-    '''
-    Get pH value description from a shift file
-    '''
+
+def dump_pkl(obj: object, path: Union[str, Path]) -> None:
+    with open(path, "wb") as f:
+        pickle.dump(obj, f)
+    print(f"Saved {Path.cwd()}/{path}")
+
+
+def get_pH(shift_file_path: str, default: float = 5.0) -> float:
     with open(shift_file_path) as f:
-        data=f.read()
-    regex=re.compile("pH.*\d+.*")
-    pH_line=regex.search(data)
+        data = f.read()
+    regex = re.compile(r"pH.*\d+.*")
+    pH_line = regex.search(data)
     if pH_line is None:
         return default
-    else:
-        pH_line=pH_line.group()
-        digit_re=re.compile("\d+\.\d+")
-        candidate_numbers=digit_re.findall(pH_line)
-        int_re=re.compile(" \d{1,2} ")
-        candidate_numbers.extend(int_re.findall(pH_line))
-        if len(candidate_numbers)==0:
-            return default
-        # We assume that the pH value is the closest number to the word "pH"
-        distances=[abs(pH_line.index(num)-pH_line.index("pH")) for num in candidate_numbers]
-        return eval(candidate_numbers[argmin(distances)])
+    pH_line = pH_line.group()
+    digit_re = re.compile(r"\d+\.\d+")
+    candidate_numbers = digit_re.findall(pH_line)
+    int_re = re.compile(r" \d{1,2} ")
+    candidate_numbers.extend(int_re.findall(pH_line))
+    if not candidate_numbers:
+        return default
+    distances = [abs(pH_line.index(num) - pH_line.index("pH")) for num in candidate_numbers]
+    return float(eval(candidate_numbers[argmin(distances)]))
 
-def get_res(file):
+
+def get_res(file: str) -> Optional[float]:
     with open(file) as f:
-        data=f.read()
-    regex=re.compile("RESOLUTION.*\d+\.\d+.*ANGSTROMS.")
-    resolution_line=regex.search(data)
+        data = f.read()
+    regex = re.compile(r"RESOLUTION.*\d+\.\d+.*ANGSTROMS.")
+    resolution_line = regex.search(data)
     if resolution_line is None:
         return None
-    else:
-        resolution_line=resolution_line.group()
-    digit_re=re.compile("\d+\.\d+")
-    resolution=digit_re.search(resolution_line)
+    digit_re = re.compile(r"\d+\.\d+")
+    resolution = digit_re.search(resolution_line.group())
     if resolution is None:
         return None
-    else:
-        resolution=eval(resolution.group())
-    return resolution
-    
-def get_free_gpu():
-    gpu_stats = subprocess.check_output(["nvidia-smi", "--format=csv", "--query-gpu=memory.used,memory.free"])
-    gpu_df = pd.read_csv(StringIO(gpu_stats.decode("utf-8").replace("MiB","")),
-                         names=['memory.used', 'memory.free'],
-                         skiprows=1)
-    gpu_df["usage"]=gpu_df["memory.free"]/(gpu_df["memory.used"]+gpu_df["memory.free"])
-    idx = gpu_df['usage'].idxmax()
-    if gpu_df.loc[idx,"usage"]<0.1:
-        idx=None
+    return float(eval(resolution.group()))
+
+
+def get_free_gpu() -> Optional[int]:
+    gpu_stats = subprocess.check_output(
+        ["nvidia-smi", "--format=csv", "--query-gpu=memory.used,memory.free"]
+    )
+    gpu_df = pd.read_csv(
+        StringIO(gpu_stats.decode("utf-8").replace("MiB", "")),
+        names=["memory.used", "memory.free"],
+        skiprows=1,
+    )
+    gpu_df["usage"] = gpu_df["memory.free"] / (gpu_df["memory.used"] + gpu_df["memory.free"])
+    idx = gpu_df["usage"].idxmax()
+    if gpu_df.loc[idx, "usage"] < 0.1:
+        return None
     return idx

--- a/ucbshifty.py
+++ b/ucbshifty.py
@@ -1,683 +1,701 @@
-#!/usr/bin/env python
-# This program executes both sequence-based alignment (using BLAST) and structure-based alignment (usint mTM-align) to find the best alignment for a specific pdb file with entities in the refDB database, and use the average chemical shifts from refDB to predict the chemical shifts for backbone H/C/N atom chemical shifts for the query protein
+#!/usr/bin/env python3
+# Transfer-prediction (UCBShift-Y) module.
+# Predicts chemical shifts by transferring shifts from similar proteins in
+# refDB via sequence alignment (BLAST) and structure alignment (mTM-align).
 
-# Author: Jie Li
-# Date created: Aug 21, 2019
-
-import Bio
-from Bio import PDB
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio import SeqIO
-from Bio import Align
-from Bio.SubsMat.MatrixInfo import blosum62
-from save_pdb import PDBSaver
-import subprocess
 import os
 import shutil
 import sys
-import toolbox
-import pandas as pd
-import numpy as np
 import argparse
+from pathlib import Path
+from typing import Optional
 
-DEBUG=False
-GLOBAL_TEST_CUTOFF=0.99
-SCRIPT_PATH=os.path.dirname(os.path.realpath(__file__))
-BLAST_DEFAULT_EXE=SCRIPT_PATH+"/bins/ncbi-blast-2.9.0+/bin/blastp"
-MTM_DEFAULT_EXE=SCRIPT_PATH+"/bins/mTM-align/mTM-align"
-os.environ["BLASTDB"]=SCRIPT_PATH+"/refDB/"  # Set the refDB position
+import numpy as np
+import pandas as pd
+from Bio import PDB, SeqIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio import Align
+from Bio.Align import substitution_matrices
 
-# Do checks beforehand to make sure the two alignment programs: BLAST and mTM-align are installed and configured correctly
-# try:
-#     check_result=subprocess.check_output(["which","blastp"])
-# except:
-#     check_result=""
-# assert len(check_result)!=0,"Cannot find BLAST program! Please make sure BLAST is correctly configured."
-# try:
-#     check_result=subprocess.check_output(["which","mTM-align"])
-# except:
-#     check_result=""
-# assert len(check_result)!=0,"Cannot find mTM-align program! Please make sure mTM-align is correctly configured."
+import toolbox
+from save_pdb import PDBSaver
 
-# Decompress refDB pdb files if they don't exist
-if not os.path.exists(SCRIPT_PATH+"/refDB/pdbs/"):
-    os.makedirs(SCRIPT_PATH+"/refDB/pdbs")
+# ── Module-level constants ────────────────────────────────────────────────────
+
+DEBUG = False
+GLOBAL_TEST_CUTOFF = 0.99
+SCRIPT_PATH = Path(os.path.dirname(os.path.realpath(__file__)))
+BLAST_DEFAULT_EXE = str(SCRIPT_PATH / "bins" / "ncbi-blast-2.9.0+" / "bin" / "blastp")
+MTM_DEFAULT_EXE = str(SCRIPT_PATH / "bins" / "mTM-align" / "mTM-align")
+os.environ["BLASTDB"] = str(SCRIPT_PATH / "refDB")
+
+BLOSUM62 = substitution_matrices.load("BLOSUM62")
+
+# Decompress refDB PDB files on first run
+_REFDB_PDBS = SCRIPT_PATH / "refDB" / "pdbs"
+if not _REFDB_PDBS.exists():
+    _REFDB_PDBS.mkdir(parents=True)
     print("Decompressing mTM-align database...")
-    os.system("tar -xzf %s/refDB/pdbs.tgz -C %s/refDB/"%(SCRIPT_PATH,SCRIPT_PATH))
+    os.system(f"tar -xzf {SCRIPT_PATH}/refDB/pdbs.tgz -C {SCRIPT_PATH}/refDB/")
 
-# ================ Define Random Coils ======================
-# Wishart et al. in J-Bio NMR, 5 (1995) 67-81.
-paper_order = ['Ala', 'Cys','Asp','Glu','Phe','Gly','His','Ile','Lys','Leu','Met','Asn','Pro','Gln','Arg','Ser','Thr','Val','Trp','Tyr']
+# ── Random coil values (Wishart et al., J-Bio NMR, 5 (1995) 67-81) ──────────
 
-paper_order = [i.upper() for i in paper_order]
+_PAPER_ORDER = [
+    'ALA', 'CYS', 'ASP', 'GLU', 'PHE', 'GLY', 'HIS', 'ILE', 'LYS', 'LEU',
+    'MET', 'ASN', 'PRO', 'GLN', 'ARG', 'SER', 'THR', 'VAL', 'TRP', 'TYR',
+]
 
-rc_ala = {}
-rc_ala['N'] = [123.8, 118.7, 120.4, 120.2, 120.3, 108.8, 118.2, 119.9,
-               120.4, 121.8, 119.6, 118.7, np.nan, 119.8, 120.5, 115.7,
-               113.6, 119.2, 121.3, 120.3]
-rc_ala['H'] = [8.24, (8.32 + 8.43) / 2, 8.34, 8.42, 8.30, 8.33, 8.42, 8.00,
-               8.29, 8.16, 8.28, 8.40, np.nan, 8.32, 8.23, 8.31, 8.15, 8.03,
-               8.25, 8.12]
-rc_ala['HA'] = [4.32, 4.55, 4.71, 4.64, 4.35, 4.62, 3.96, 4.73, 4.17, 4.32,
-                4.34, 4.48, 4.74, 4.42, 4.34, 4.3, 4.47, 4.35, 4.12, 4.66,
-                4.55]
-rc_ala['C'] = [177.8, 174.6, 176.3, 176.6, 175.8, 174.9, 174.1, 176.4, 176.6,
-               177.6, 176.3, 175.2, 177.3, 176.0, 176.3, 174.6, 174.7, 176.3,
-               176.1, 175.9]
-rc_ala['CA'] = [52.5, (58.2 + 55.4) / 2, 54.2, 56.6, 57.7, 45.1, 55.0, 61.1,
-                56.2, 55.1, 55.4, 53.1, 63.3, 55.7, 56.0, 58.3, 61.8, 62.2,
-                57.5, 57.9]
-rc_ala['CB'] = [19.1, (28 + 41.1) / 2, 41.1, 29.9, 39.6, np.nan, 29, 38.8, 33.1,
-                42.4, 32.9, 38.9, 32.1, 29.4, 30.9, 63.8, 69.8, 32.9, 29.6,
-                38.8]
-randcoil_ala = {i: dict(zip(paper_order, rc_ala[i])) for i in toolbox.ATOMS}
-# When the residue in question is followed by a Proline, we instead use:
-rc_pro = {}
-rc_pro['N'] = [125, 119.9, 121.4, 121.7, 120.9, 109.1, 118.2, 121.7, 121.6,
-               122.6, 120.7, 119.0, np.nan, 120.6, 121.3, 116.6, 116.0, 120.5,
-               122.2, 120.8]
-rc_pro['H'] = [8.19, 8.30, 8.31, 8.34, 8.13, 8.21, 8.37, 8.06, 8.18,
-               8.14, 8.25, 8.37, np.nan, 8.29, 8.2, 8.26, 8.15, 8.02, 8.09,
-               8.1]
-rc_pro['HA'] = [4.62, 4.81, 4.90, 4.64, 4.9, 4.13, 5.0, 4.47, 4.60, 4.63, 4.82,
-                5.0, 4.73, 4.65, 4.65, 4.78, 4.61, 4.44, 4.99, 4.84]
-rc_pro['C'] = [175.9, 173, 175, 174.9, 174.4, 174.5, 172.6, 175.0, 174.8,
-               175.7, 174.6, 173.6, 171.4, 174.4, 174.5, 173.1, 173.2, 174.9,
-               174.8, 174.8]
-rc_pro['CA'] = [50.5, 56.4, 52.2, 54.2, 55.6, 44.5, 53.3, 58.7, 54.2, 53.1,
-                53.3, 51.3, 61.5, 53.7, 54.0, 56.4, 59.8, 59.8, 55.7, 55.8]
-rc_pro['CB'] = [18.1, 27.1, 40.9, 29.2, 39.1, np.nan, 29.0, 38.7, 32.6, 41.7,
-                32.4, 38.7, 30.9, 28.8, 30.2, 63.3, 69.8, 32.6, 28.9, 38.3]
-randcoil_pro = {i: dict(zip(paper_order, rc_pro[i])) for i in toolbox.ATOMS}
+_rc_ala: dict[str, list] = {
+    'N':  [123.8, 118.7, 120.4, 120.2, 120.3, 108.8, 118.2, 119.9, 120.4, 121.8,
+           119.6, 118.7, np.nan, 119.8, 120.5, 115.7, 113.6, 119.2, 121.3, 120.3],
+    'H':  [8.24, (8.32+8.43)/2, 8.34, 8.42, 8.30, 8.33, 8.42, 8.00, 8.29, 8.16,
+           8.28, 8.40, np.nan, 8.32, 8.23, 8.31, 8.15, 8.03, 8.25, 8.12],
+    'HA': [4.32, 4.55, 4.71, 4.64, 4.35, 4.62, 3.96, 4.73, 4.17, 4.32,
+           4.34, 4.48, 4.74, 4.42, 4.34, 4.3, 4.47, 4.35, 4.12, 4.66, 4.55],
+    'C':  [177.8, 174.6, 176.3, 176.6, 175.8, 174.9, 174.1, 176.4, 176.6, 177.6,
+           176.3, 175.2, 177.3, 176.0, 176.3, 174.6, 174.7, 176.3, 176.1, 175.9],
+    'CA': [52.5, (58.2+55.4)/2, 54.2, 56.6, 57.7, 45.1, 55.0, 61.1, 56.2, 55.1,
+           55.4, 53.1, 63.3, 55.7, 56.0, 58.3, 61.8, 62.2, 57.5, 57.9],
+    'CB': [19.1, (28+41.1)/2, 41.1, 29.9, 39.6, np.nan, 29, 38.8, 33.1, 42.4,
+           32.9, 38.9, 32.1, 29.4, 30.9, 63.8, 69.8, 32.9, 29.6, 38.8],
+}
+_rc_pro: dict[str, list] = {
+    'N':  [125, 119.9, 121.4, 121.7, 120.9, 109.1, 118.2, 121.7, 121.6, 122.6,
+           120.7, 119.0, np.nan, 120.6, 121.3, 116.6, 116.0, 120.5, 122.2, 120.8],
+    'H':  [8.19, 8.30, 8.31, 8.34, 8.13, 8.21, 8.37, 8.06, 8.18, 8.14,
+           8.25, 8.37, np.nan, 8.29, 8.2, 8.26, 8.15, 8.02, 8.09, 8.1],
+    'HA': [4.62, 4.81, 4.90, 4.64, 4.9, 4.13, 5.0, 4.47, 4.60, 4.63, 4.82,
+           5.0, 4.73, 4.65, 4.65, 4.78, 4.61, 4.44, 4.99, 4.84],
+    'C':  [175.9, 173, 175, 174.9, 174.4, 174.5, 172.6, 175.0, 174.8, 175.7,
+           174.6, 173.6, 171.4, 174.4, 174.5, 173.1, 173.2, 174.9, 174.8, 174.8],
+    'CA': [50.5, 56.4, 52.2, 54.2, 55.6, 44.5, 53.3, 58.7, 54.2, 53.1,
+           53.3, 51.3, 61.5, 53.7, 54.0, 56.4, 59.8, 59.8, 55.7, 55.8],
+    'CB': [18.1, 27.1, 40.9, 29.2, 39.1, np.nan, 29.0, 38.7, 32.6, 41.7,
+           32.4, 38.7, 30.9, 28.8, 30.2, 63.3, 69.8, 32.6, 28.9, 38.3],
+}
 
-EXTERNAL_MAPPINGS = {"HIE":"HIS","HID":"HIS","HIP":"HIS","CAS":"CYS","CSD":"CYS","MSE":"MET","CSO":"CYS"}
+randcoil_ala = {atom: dict(zip(_PAPER_ORDER, _rc_ala[atom])) for atom in toolbox.ATOMS}
+randcoil_pro = {atom: dict(zip(_PAPER_ORDER, _rc_pro[atom])) for atom in toolbox.ATOMS}
 
+EXTERNAL_MAPPINGS = {
+    "HIE": "HIS", "HID": "HIS", "HIP": "HIS",
+    "CAS": "CYS", "CSD": "CYS", "MSE": "MET", "CSO": "CYS",
+}
 SS_CAPS = {"H": 3.7, "HA": 3, "C": 10, "CA": 11.25, "CB": 20, "N": 22}
 
-def read_sing_chain_PDB(path,fix_unknown_res=True,remove_alternate_res=True):
-    '''
-    Reads a pdb file from path and check whether it is single-chained. If true, return the chain object
-    fix_unknown_res = whether or not change the residues with non-standard names into standard names using EXTERNAL_MAPPINGS
-    remove_duplicate_res = whether or not remove alternate residues (two residues at the same resnum position) in the chain
-    '''
-    parser=PDB.PDBParser()
-    struc=parser.get_structure("query",path)
-    if len(struc)>1:
-        print("Multiple models exist in this pdb file! Only the first model is taken.")
-    struc=struc[0]
-    assert len(struc)==1,"Multiple chains exist in this pdb file!"
-    chain=struc.child_list[0]
+
+# ── Utility functions ─────────────────────────────────────────────────────────
+
+def get_blosum_value(resname1: str, resname2: str) -> int:
+    """Return the BLOSUM62 substitution score between two residues (3-letter codes)."""
+    code1, code2 = toolbox.form_seq([resname1, resname2])
+    return int(BLOSUM62[code1, code2])
+
+
+def _extract_aligned_seqs(alignment) -> tuple[str, str]:
+    """Parse gapped aligned sequences from a Bio.Align PairwiseAlignment object.
+
+    Returns (target_gapped, query_gapped) where target = seq1 and query = seq2
+    as passed to aligner.align(seq1, seq2).
+    """
+    fmt = format(alignment)
+    target_parts: list[str] = []
+    query_parts: list[str] = []
+    for line in fmt.split("\n"):
+        tokens = line.split()
+        if len(tokens) >= 3:
+            if tokens[0] == "target":
+                target_parts.append(tokens[2])
+            elif tokens[0] == "query":
+                query_parts.append(tokens[2])
+    return "".join(target_parts), "".join(query_parts)
+
+
+def Needleman_Wunsch_alignment(seq1: str, seq2: str) -> tuple[str, str]:
+    """Global sequence alignment using BLOSUM62 via Needleman-Wunsch.
+
+    Returns (aligned_seq1, aligned_seq2) with gap characters ('-').
+    """
+    missing = None
+    if "-" in seq1:
+        missing = [s == "-" for s in seq1]
+        seq1 = seq1.replace("-", "")
+
+    aligner = Align.PairwiseAligner()
+    aligner.mode = "global"
+    aligner.open_gap_score = -10
+    aligner.extend_gap_score = -0.5
+    aligner.substitution_matrix = BLOSUM62
+
+    alignment = aligner.align(seq1, seq2)[0]
+    aligned1, aligned2 = _extract_aligned_seqs(alignment)
+
+    if missing is None:
+        return aligned1, aligned2
+
+    # Re-insert the positions that were originally '-' in seq1
+    final1_temp, final2_temp = [], []
+    j = 0
+    for s in missing:
+        if s:
+            final1_temp.append("-")
+            final2_temp.append("-")
+        else:
+            while j < len(aligned1) and aligned1[j] == "-":
+                final1_temp.append(aligned1[j])
+                final2_temp.append(aligned2[j])
+                j += 1
+            if j < len(aligned1):
+                final1_temp.append(aligned1[j])
+                final2_temp.append(aligned2[j])
+                j += 1
+    if j < len(aligned1):
+        final1_temp.extend(aligned1[j:])
+        final2_temp.extend(aligned2[j:])
+
+    # Remove double-gap positions introduced by the re-insertion
+    final1, final2 = [], []
+    for a, b in zip(final1_temp, final2_temp):
+        if not (a == "-" and b == "-"):
+            final1.append(a)
+            final2.append(b)
+    return "".join(final1), "".join(final2)
+
+
+# ── PDB I/O ───────────────────────────────────────────────────────────────────
+
+def read_sing_chain_PDB(
+    path: str,
+    fix_unknown_res: bool = True,
+    remove_alternate_res: bool = True,
+):
+    """Parse a single-chain PDB file and return its chain object."""
+    parser = PDB.PDBParser(QUIET=True)
+    struc = parser.get_structure("query", path)
+    if len(struc) > 1:
+        print("Multiple models exist in this PDB file — only the first model is used.")
+    struc = struc[0]
+    assert len(struc) == 1, "Multiple chains exist in this PDB file!"
+    chain = struc.child_list[0]
+
     if fix_unknown_res:
-        deletion=[]
-        existing_resnum=[]
-        for i in range(len(chain.child_list)):
-            if chain.child_list[i].resname in EXTERNAL_MAPPINGS:
-                print("Warning: residue %s[%d] is recognized as %s"%(chain.child_list[i].resname,chain.child_list[i].id[1],EXTERNAL_MAPPINGS[chain.child_list[i].resname]))
-                chain.child_list[i].resname=EXTERNAL_MAPPINGS[chain.child_list[i].resname]
-            elif chain.child_list[i].resname not in toolbox.protein_dict:
-                # Removing the unrecognized residues
-                print("Warning: Unknown residue encountered: %s[%d]"%(chain.child_list[i].resname,chain.child_list[i].id[1]))
-                deletion.append(chain.child_list[i].id)
+        deletion = []
+        existing_resnum: list[int] = []
+        for residue in chain.child_list:
+            if residue.resname in EXTERNAL_MAPPINGS:
+                print(
+                    f"Warning: residue {residue.resname}[{residue.id[1]}] "
+                    f"is recognised as {EXTERNAL_MAPPINGS[residue.resname]}"
+                )
+                residue.resname = EXTERNAL_MAPPINGS[residue.resname]
+            elif residue.resname not in toolbox.protein_dict:
+                print(f"Warning: unknown residue encountered: {residue.resname}[{residue.id[1]}]")
+                deletion.append(residue.id)
             if remove_alternate_res:
-                if chain.child_list[i].id[1] in existing_resnum:
-                    print("Warning: residue %s[%d%s] ignored because it is an alternate residue"%(chain.child_list[i].resname,chain.child_list[i].id[1],chain.child_list[i].id[2]))
-                    deletion.append(chain.child_list[i].id)
+                if residue.id[1] in existing_resnum:
+                    print(
+                        f"Warning: residue {residue.resname}[{residue.id[1]}"
+                        f"{residue.id[2]}] ignored (alternate residue)"
+                    )
+                    deletion.append(residue.id)
                 else:
-                    existing_resnum.append(chain.child_list[i].id[1])
-        if len(deletion)>0:
-            for item in deletion:
-                chain.detach_child(item)
-        saver=PDBSaver()
+                    existing_resnum.append(residue.id[1])
+        for item in deletion:
+            chain.detach_child(item)
+        saver = PDBSaver()
         saver.set_structure(chain)
-        basename=os.path.basename(path)
-        saver.save(basename.replace(".pdb","_fix.pdb"))
+        basename = os.path.basename(path)
+        saver.save(basename.replace(".pdb", "_fix.pdb"))
     return chain
 
-def chain_to_seq(chain,fasta_output=None,res_num=True):
-    '''
-    Accepts a biopython chain object and returns the sequence of that chain
-    fasta_output = if not None, output the sequence to a fasta file
-    res_num = if true, return the residue numbers in the original PDB file along with the sequence
-    '''
-    residues=[]
-    resnum=[]
+
+def chain_to_seq(chain, fasta_output: Optional[str] = None, res_num: bool = True):
+    """Extract the amino-acid sequence (and optionally residue numbers) from a chain."""
+    residues, resnum = [], []
     for residue in chain.child_list:
         if residue.resname in toolbox.protein_dict:
             residues.append(residue.resname)
             resnum.append(residue.id[1])
-    seq=Seq(toolbox.form_seq(residues))
+    seq = Seq(toolbox.form_seq(residues))
     if fasta_output:
-        record=SeqRecord(seq,id="query",description="")
-        with open(fasta_output,"w") as f:
+        record = SeqRecord(seq, id="query", description="")
+        with open(fasta_output, "w") as f:
             f.write(record.format("fasta"))
-    if res_num:
-        return seq,resnum
-    else:
-        return seq
+    return (seq, resnum) if res_num else seq
+
+
+# ── BLAST alignment ───────────────────────────────────────────────────────────
 
 class blast_result:
-    def __init__(self):
-        self.target_name=""
-        self.score=0
-        self.Evalue=0
-        self.Lmatch=0 # Matched length
-        self.Tmatch=0 # Total length of matched region in matched sequence
-        self.source_seq=""
-        self.target_seq=""
-        self.coverage=0
-        self.__last_source_num=0
-        self.__last_target_num=0
+    def __init__(self) -> None:
+        self.target_name = ""
+        self.score = 0.0
+        self.Evalue = 0.0
+        self.Lmatch = 0
+        self.Tmatch = 0
+        self.source_seq = ""
+        self.target_seq = ""
+        self.coverage = 0.0
+        self._last_source_num = 0
+        self._last_target_num = 0
 
-    def parse(self,line):
-        '''
-        Function to parse pdb name, blast score and Evalue from a line in blast output file
-        '''
-        self.target_name=line.split()[0]
-        self.score=float(line.split()[-2])
-        self.Evalue=float(line.split()[-1])
+    def parse(self, line: str) -> None:
+        parts = line.split()
+        self.target_name = parts[0]
+        self.score = float(parts[-2])
+        self.Evalue = float(parts[-1])
 
-    def parse_match(self,line):
-        '''
-        Function to parse matching length from a line in blast output file
-        '''
-        identity_entry=line.split(",")[0]
-        number_entry=[entry for entry in identity_entry.split() if "/" in entry][0]
-        self.Lmatch,self.Tmatch=[int(n) for n in number_entry.split("/")]
+    def parse_match(self, line: str) -> None:
+        identity_entry = line.split(",")[0]
+        number_entry = next(e for e in identity_entry.split() if "/" in e)
+        self.Lmatch, self.Tmatch = (int(n) for n in number_entry.split("/"))
 
-    def parse_seq(self,line,obj):
-        '''
-        Functionb to parse blast source/target sequence in a line of the blast output file
-        obj = "source" / "target"
-        '''
-        start_num=int(line.split()[1])
-        end_num=int(line.split()[3])
-        if obj=="source":
-            if self.source_seq=="" or start_num==self.__last_source_num+1:
-                self.source_seq+=line.split()[2]
-                self.__last_source_num=end_num
-        elif obj=="target":
-            if self.target_seq=="" or start_num==self.__last_target_num+1:
-                self.target_seq+=line.split()[2]
-                self.__last_target_num=end_num
+    def parse_seq(self, line: str, obj: str) -> None:
+        start_num = int(line.split()[1])
+        end_num = int(line.split()[3])
+        if obj == "source":
+            if self.source_seq == "" or start_num == self._last_source_num + 1:
+                self.source_seq += line.split()[2]
+                self._last_source_num = end_num
+        elif obj == "target":
+            if self.target_seq == "" or start_num == self._last_target_num + 1:
+                self.target_seq += line.split()[2]
+                self._last_target_num = end_num
 
-    def calc_coverage(self,len_total):
-        '''
-        Calculate coverage of a blast match. Because the source sequence from blast may be shorter than the real sequence, the total length of the real sequence must be provided.
-        '''
-        assert self.source_seq!="" and self.target_seq!=""
-        # self.coverage=len([i for i in range(len(self.source_seq)) if self.source_seq[i]==self.target_seq[i]])/len_total
-        self.coverage=self.Lmatch/max(self.Tmatch,len_total)
+    def calc_coverage(self, len_total: int) -> None:
+        assert self.source_seq != "" and self.target_seq != ""
+        self.coverage = self.Lmatch / max(self.Tmatch, len_total)
 
 
-def blast(seq,db_name="refDB.blastdb",cleaning=True,return_aligned_seq=False,working_dir=None):
-    '''
-    Execute a blast query on the sequence and return the blast results
-    seq = the query sequence (type: Bio.Seq.Seq) or the path to the fasta file (type: str)
-    db_name = the name of blast database
-    cleaning = if true, clean the files and folders generated by executing the blast program
-    return_aligned_seq = whether include the aligned sequences in the blast_result
-    working_dir = a folder to store the intermediate results
-    '''
+def blast(
+    seq,
+    db_name: str = "refDB.blastdb",
+    cleaning: bool = True,
+    return_aligned_seq: bool = False,
+    working_dir: Optional[str] = None,
+) -> dict:
     if working_dir is None:
-        working_dir="blast/"
+        working_dir = "blast/"
     if os.path.exists(working_dir):
         shutil.rmtree(working_dir)
     os.mkdir(working_dir)
-    if type(seq) is str:
-        fasta_name=working_dir+os.path.split(seq)[-1]
-        shutil.copy(seq,fasta_name)
-    elif type(seq) is Bio.Seq.Seq:
-        fasta_name=working_dir+"query.fasta"
-        record=SeqRecord(seq,id="query",description="")
-        with open(fasta_name,"w") as f:
+    if isinstance(seq, str):
+        fasta_name = working_dir + os.path.split(seq)[-1]
+        shutil.copy(seq, fasta_name)
+    else:
+        fasta_name = working_dir + "query.fasta"
+        record = SeqRecord(Seq(str(seq)), id="query", description="")
+        with open(fasta_name, "w") as f:
             f.write(record.format("fasta"))
-    cmd=BLAST_DEFAULT_EXE+" -db %s -query %s -out %s  > /dev/null 2>&1"%(db_name,fasta_name,working_dir+"blast.out")
+    cmd = (
+        f"{BLAST_DEFAULT_EXE} -db {db_name} -query {fasta_name} "
+        f"-out {working_dir}blast.out > /dev/null 2>&1"
+    )
     os.system(cmd)
-    results={}
-    mode="ignore"
-    for line in open(working_dir+"blast.out"):
+    results: dict[str, blast_result] = {}
+    mode = "ignore"
+    for line in open(working_dir + "blast.out"):
         if "Sequences producing significant alignments:" in line:
-            mode="add_match"
+            mode = "add_match"
             continue
-        elif line[0]==">":
-                mode=line.split()[0].replace(">","")
-        if mode=="add_match" and line.strip()!="":
-            result=blast_result()
+        elif line[0] == ">":
+            mode = line.split()[0].replace(">", "")
+        if mode == "add_match" and line.strip():
+            result = blast_result()
             result.parse(line)
-            results[result.target_name]=result
+            results[result.target_name] = result
         else:
-            if mode!="ignore":
+            if mode != "ignore":
                 if "Identities =" in line:
-                    if results[mode].source_seq=="":
+                    if results[mode].source_seq == "":
                         results[mode].parse_match(line)
                     else:
-                        mode="ignore"
+                        mode = "ignore"
                 elif "Query" in line and return_aligned_seq:
-                    results[mode].parse_seq(line,"source")
+                    results[mode].parse_seq(line, "source")
                 elif "Sbjct" in line and return_aligned_seq:
-                    results[mode].parse_seq(line,"target")
+                    results[mode].parse_seq(line, "target")
     for identifier in results:
         results[identifier].calc_coverage(len(seq))
     if cleaning:
         shutil.rmtree(working_dir)
     return results
 
-class mTM_align_result:
-    def __init__(self,pdbid):
-        self.target_name=pdbid
-        self.rmsd=0
-        self.TMscore=0
-        self.source_seq=""
-        self.target_seq=""
-        self.coverage=0
-    
-    def parse_alignment(self,source_seq, target_seq):
-        '''
-        Function to parse the alignment generated by mTM-align (multiple sequences alignment) to the alignments between two
-        '''
-        assert len(source_seq)==len(target_seq)
-        for i in range(len(source_seq)):
-            if source_seq[i]=="-" and target_seq[i]=="-":
-                continue
-            else:
-                self.source_seq+=source_seq[i]
-                self.target_seq+=target_seq[i]
-        self.coverage=len([i for i in range(len(self.source_seq)) if self.source_seq[i]==self.target_seq[i]])/len(self.source_seq)
 
-def mTM_align(source_file,alignment_candidates,db_path=SCRIPT_PATH+"/refDB/pdbs/",cleaning=True,working_dir=None):
-    '''
-    Execute a multiple structure alignment for the specified source file with the candidate alignment structures using the mTM-alignment algorithm
-    source_file = file name of the PDB to be aligned with (type: str)
-    alignment_candidates = all candidate alignment PDBIDs (with chain ID) that need to be aligned with (type: List of str)
-    db_path = path that all refDB single chain PDB files are stored
-    cleaning = if true, clean the files and folders generated by executing mTM-align
-    working_dir = a folder to store the intermediate results
-    '''
+# ── mTM-align structural alignment ───────────────────────────────────────────
+
+class mTM_align_result:
+    def __init__(self, pdbid: str) -> None:
+        self.target_name = pdbid
+        self.rmsd = 0.0
+        self.TMscore = 0.0
+        self.source_seq = ""
+        self.target_seq = ""
+        self.coverage = 0.0
+
+    def parse_alignment(self, source_seq: str, target_seq: str) -> None:
+        assert len(source_seq) == len(target_seq)
+        for s, t in zip(source_seq, target_seq):
+            if s == "-" and t == "-":
+                continue
+            self.source_seq += s
+            self.target_seq += t
+        matches = sum(1 for s, t in zip(self.source_seq, self.target_seq) if s == t)
+        self.coverage = matches / len(self.source_seq)
+
+
+def mTM_align(
+    source_file: str,
+    alignment_candidates: list,
+    db_path: Optional[str] = None,
+    cleaning: bool = True,
+    working_dir: Optional[str] = None,
+) -> dict:
+    if db_path is None:
+        db_path = str(SCRIPT_PATH / "refDB" / "pdbs") + "/"
     if working_dir is None:
-        working_dir="mTM_align/"
+        working_dir = "mTM_align/"
     if os.path.exists(working_dir):
         shutil.rmtree(working_dir)
     os.mkdir(working_dir)
-    shutil.copy(source_file,working_dir+"query.pdb")
+    shutil.copy(source_file, working_dir + "query.pdb")
     for candidate in alignment_candidates:
-        shutil.copy(db_path+candidate.split(".")[1]+".pdb",working_dir+"%s.pdb"%candidate)
-    with open(working_dir+"inputs","w") as f:
+        shutil.copy(db_path + candidate.split(".")[1] + ".pdb", f"{working_dir}{candidate}.pdb")
+    with open(working_dir + "inputs", "w") as f:
         f.write("query.pdb\n")
         for candidate in alignment_candidates:
-            f.write("%s.pdb\n"%candidate)
+            f.write(f"{candidate}.pdb\n")
     os.chdir(working_dir)
-    cmd=MTM_DEFAULT_EXE+" -i inputs"+" > /dev/null 2>&1"
-    os.system(cmd)
-    results={candidate:mTM_align_result(candidate) for candidate in alignment_candidates}
+    os.system(f"{MTM_DEFAULT_EXE} -i inputs > /dev/null 2>&1")
+
+    results = {c: mTM_align_result(c) for c in alignment_candidates}
+
     with open("pairwise_rmsd.txt") as f:
-        title=f.readline() # Read the first line that is the title
-        title=[item.replace(".pdb","") for item in title.split()]
-        for line in f:
-            if "query.pdb" in line:
-                wanted_line=line # The line starts with "query.pdb" contains the alignment information that we want
-    for rmsd,candidate_pdb in zip(wanted_line.split()[1:],title):
-        if candidate_pdb!="query":
-            results[candidate_pdb].rmsd=float(rmsd)
+        title = [t.replace(".pdb", "") for t in f.readline().split()]
+        query_line = next(l for l in f if "query.pdb" in l)
+    for rmsd, candidate_pdb in zip(query_line.split()[1:], title):
+        if candidate_pdb != "query":
+            results[candidate_pdb].rmsd = float(rmsd)
+
     with open("pairwise_TMscore.txt") as f:
-        title=f.readline() # Read the first line that is the title
-        title=[item.replace(".pdb","") for item in title.split()]
-        for line in f:
-            if "query.pdb" in line:
-                wanted_line=line # The line starts with "query.pdb" contains the alignment information that we want
-    for score,candidate_pdb in zip(wanted_line.split()[1:],title):
-        if candidate_pdb!="query":
-            results[candidate_pdb].TMscore=float(score)
-    # Read alignments
-    all_alignments=SeqIO.parse("result.fasta","fasta")
-    alignment_seqs={}
-    for alignment in all_alignments:
-        if alignment.id=="query.pdb":
-            query_seq=alignment.seq
+        title = [t.replace(".pdb", "") for t in f.readline().split()]
+        query_line = next(l for l in f if "query.pdb" in l)
+    for score, candidate_pdb in zip(query_line.split()[1:], title):
+        if candidate_pdb != "query":
+            results[candidate_pdb].TMscore = float(score)
+
+    all_alignments = SeqIO.parse("result.fasta", "fasta")
+    alignment_seqs: dict = {}
+    query_seq = None
+    for aln in all_alignments:
+        if aln.id == "query.pdb":
+            query_seq = aln.seq
         else:
-            alignment_seqs[alignment.id.replace(".pdb","")]=alignment.seq
-    for seq in alignment_seqs:
-        results[seq].parse_alignment(query_seq,alignment_seqs[seq])
+            alignment_seqs[aln.id.replace(".pdb", "")] = aln.seq
+    for seq_id, target_seq in alignment_seqs.items():
+        results[seq_id].parse_alignment(str(query_seq), str(target_seq))
+
     os.chdir("../")
     if cleaning:
         shutil.rmtree(working_dir)
     return results
 
-def get_blosum_value(resname1,resname2):
-    '''
-    Function for acquiring the BLOSUM62 substitution score from res1 to res2
-    '''
-    code1,code2=toolbox.form_seq([resname1,resname2])
-    if (code1,code2) in blosum62:
-        return blosum62[(code1,code2)]
+
+# ── Shift assignment ──────────────────────────────────────────────────────────
+
+def assign_aligned_shifts(
+    source_seq: str,
+    target_seq: str,
+    target_id: str,
+    refDB: pd.DataFrame,
+    strict: int,
+) -> list:
+    """Transfer chemical shifts from a reference protein to the query sequence.
+
+    strict: 0 = exact match only, 1 = BLOSUM62 > 0, 2 = permissive.
+    Returns a list of dicts (one per query residue) with secondary shift values.
+    """
+    if (refDB.RES_NUM == np.arange(len(refDB)) + 1).all():
+        refDB_seq = toolbox.form_seq(refDB.RESNAME)
     else:
-        return blosum62[(code2,code1)]
-
-def Needleman_Wunsch_alignment(seq1,seq2):
-    '''
-    Function for doing global alignment between seq1 and seq2 using Needleman-Wunsch algorithm implemented in Biopython
-    '''
-    missing=None
-    if "-" in seq1:
-        # Need to handle "-" beforehand, otherwise the alignment may fail
-        missing=[s=="-" for s in seq1]
-        seq1=seq1.replace("-","")
-    aligner=Align.PairwiseAligner()
-    aligner.open_gap_score=-10
-    aligner.extend_gap_score=-0.5
-    aligner.substitution_matrix=blosum62
-    alignment=aligner.align(seq1,seq2)[0]
-    alignment_info=alignment.__str__().split("\n")
-    aligned1,aligned2=alignment_info[0],alignment_info[2]
-    if missing is None:
-        final1=aligned1
-        final2=aligned2
-    else:
-        # Assign alignment with "-"
-        final1_temp=""
-        final2_temp=""
-        j=0
-        for s in missing:
-            if s:
-                final1_temp+="-"
-                final2_temp+="-"
-            else:
-                while aligned1[j]=="-" and j<len(aligned1):
-                    final1_temp+=aligned1[j]
-                    final2_temp+=aligned2[j]
-                    j+=1
-                if j<len(aligned1):
-                    final1_temp+=aligned1[j]
-                    final2_temp+=aligned2[j]
-                    j+=1
-        if j<len(aligned1):
-            final1_temp+=aligned1[j:]
-            final2_temp+=aligned2[j:]
-        # Cleaning up
-        final1=""
-        final2=""
-        for i in range(len(final1_temp)):
-            if not (final1_temp[i]=="-" and final2_temp[i]=="-"):
-                final1+=final1_temp[i]
-                final2+=final2_temp[i]
-    return final1,final2
-
-
-
-def assign_aligned_shifts(source_seq,target_seq,target_id,refDB,strict):
-    '''
-    Function to transfer matched sequence chemical shifts to the source sequence
-    source_seq = the input sequence with chemical shifts to be predicted (type: str)
-    target_seq = one of the matched sequence with the input sequence (type: str)
-    target_id = the PDB identifier (with chain ID) for the target sequence
-    refDB = the refDB database containing the shifts for target protein
-    strict = strictness level of shift transfer (0 - Strict, 1 - Normal, 2 - Permissive)
-
-    Returns a list, with each element being a dictionary about the chemical shift difference at that residue from random coil value for the different atom types, if a faithful match is found 
-    '''
-    if (refDB.RES_NUM==np.arange(len(refDB))+1).all():
-        # All the residue numbers are consecutive and there is no error
-        refDB_seq=toolbox.form_seq(refDB.RESNAME)
-    else:
-        refDB_seq=""
-        start=1
+        refDB_seq = ""
+        start = 1
         for i in range(len(refDB)):
-            refDB_seq+="-"*(refDB.loc[i,"RES_NUM"]-start)
-            start=refDB.loc[i,"RES_NUM"]+1
-            refDB_seq+=toolbox.form_seq([refDB.loc[i,"RESNAME"]])
-    if len(source_seq)!=len(target_seq):
-        # Make sure source seq and target seq are aligned at first place
-        source_seq,target_seq=Needleman_Wunsch_alignment(source_seq,target_seq)
-    shift_seq,pdb_seq=Needleman_Wunsch_alignment(refDB_seq,target_seq.replace("-",""))
-    # source_seq is refDB sequence of matched pdb, target_seq is PDB sequence
-    refDB_seq_shifts=[]
-    n=0
-    for i in range(len(shift_seq)):
-        if shift_seq[i]=="-":
+            refDB_seq += "-" * (refDB.loc[i, "RES_NUM"] - start)
+            start = refDB.loc[i, "RES_NUM"] + 1
+            refDB_seq += toolbox.form_seq([refDB.loc[i, "RESNAME"]])
+
+    if len(source_seq) != len(target_seq):
+        source_seq, target_seq = Needleman_Wunsch_alignment(source_seq, target_seq)
+    shift_seq, pdb_seq = Needleman_Wunsch_alignment(refDB_seq, target_seq.replace("-", ""))
+
+    # Map each position in shift_seq to a refDB row
+    refDB_seq_shifts: list[dict] = []
+    n = 0
+    for ch in shift_seq:
+        if ch == "-":
             refDB_seq_shifts.append({})
         else:
-            residue=toolbox.decode_seq(shift_seq[i])
-            assert residue==refDB.iloc[n]["RESNAME"]
-            record={atom:refDB.iloc[n][atom] for atom in toolbox.ATOMS}
-            record["TARGET_RESNAME"]=residue
-            record["TARGET_RESNAME_i+1"]=refDB.iloc[n]["RESNAME_i+1"]
+            residue = toolbox.decode_seq(ch)
+            assert residue == refDB.iloc[n]["RESNAME"]
+            record = {atom: refDB.iloc[n][atom] for atom in toolbox.ATOMS}
+            record["TARGET_RESNAME"] = residue
+            record["TARGET_RESNAME_i+1"] = refDB.iloc[n]["RESNAME_i+1"]
             refDB_seq_shifts.append(record)
-            n+=1
-    refDB_pdb_shifts=[]
-    for i in range(len(shift_seq)):
-        if pdb_seq[i]!="-":
-            refDB_pdb_shifts.append(refDB_seq_shifts[i])
-    query_ref_pdb_shifts=[]
-    n=0
-    for i in range(len(target_seq)):
-        if target_seq[i]=="-":
+            n += 1
+
+    # Drop positions where pdb_seq has a gap
+    refDB_pdb_shifts: list[dict] = [
+        refDB_seq_shifts[i] for i in range(len(shift_seq)) if pdb_seq[i] != "-"
+    ]
+
+    # Map to query positions (skipping gaps in target_seq)
+    query_ref_pdb_shifts: list[dict] = []
+    n = 0
+    for ch in target_seq:
+        if ch == "-":
             query_ref_pdb_shifts.append({})
         else:
             query_ref_pdb_shifts.append(refDB_pdb_shifts[n])
-            n+=1
-    results=[]
-    n=0
-    for i in range(len(source_seq)):
-        if source_seq[i]!="-":
-            shifts=query_ref_pdb_shifts[i]
+            n += 1
+
+    # Assign source residue names and apply strict rules
+    results: list[dict] = []
+    n = 0
+    for i, ch in enumerate(source_seq):
+        if ch != "-":
+            shifts = dict(query_ref_pdb_shifts[i])
             try:
-                shifts["SOURCE_RESNAME"]=toolbox.decode_seq(source_seq[i])
+                shifts["SOURCE_RESNAME"] = toolbox.decode_seq(ch)
             except KeyError:
-                shifts["SOURCE_RESNAME"]="UNK"
+                shifts["SOURCE_RESNAME"] = "UNK"
             results.append(shifts)
-            n+=1
-    # Finally, transfer shifts to the query sequene based on these rules:
-    #   1) If the residues are the same, shifts are directly transferred
-    #   2) If the target residue is not the same as the source residue, but the BLOSUM substitution score is larger than zero (or using CRAZY GUESS mode), the difference between target shift and random coil values for the target residue is transferred to the source residue
-    #   3) If the target residue is not the same as the source residue and the BLOSUM substitution score is smaller than zero (and not in CRAZY GUESS mode), or no matching residues, the shifts for the source residue is not given
-    for i in range(len(results)):
-        if "TARGET_RESNAME" in results[i]:
-            if strict==2 or (strict==1 and get_blosum_value(results[i]["SOURCE_RESNAME"],results[i]["TARGET_RESNAME"])>0) or (strict==0 and results[i]["SOURCE_RESNAME"]==results[i]["TARGET_RESNAME"]):
-                if results[i]["TARGET_RESNAME_i+1"]=="PRO":
-                    for atom in toolbox.ATOMS:
-                        results[i][atom]-=randcoil_pro[atom][results[i]["TARGET_RESNAME"]]
-                else:
-                    for atom in toolbox.ATOMS:
-                        results[i][atom]-=randcoil_ala[atom][results[i]["TARGET_RESNAME"]]
+            n += 1
+
+    for i, res in enumerate(results):
+        if "TARGET_RESNAME" in res:
+            accept = (
+                strict == 2
+                or (strict == 1 and get_blosum_value(res["SOURCE_RESNAME"], res["TARGET_RESNAME"]) > 0)
+                or (strict == 0 and res["SOURCE_RESNAME"] == res["TARGET_RESNAME"])
+            )
+            if accept:
+                rc = randcoil_pro if res["TARGET_RESNAME_i+1"] == "PRO" else randcoil_ala
+                for atom in toolbox.ATOMS:
+                    res[atom] -= rc[atom][res["TARGET_RESNAME"]]
             else:
-                results[i]={}
+                results[i] = {}
         else:
-            results[i]={}
+            results[i] = {}
     return results
 
-def main(path,strict,secondary=False,test=False,exclude=False,shifty=False,blast_score_threshold=0,e_value_threshold=1e-10,long_Tmatch_threshold=40,short_Tmatch_threshold=20,long_match_percent_threshold=0.15,short_match_percent_threshold=0.4,TMscore_threshold=0.8,rmsd_threshold=1.75,coverage_threshold=0.3,refDB_shifts_path=SCRIPT_PATH+"/refDB/shifts_df/",custom_working_dir=None):
-    '''
-    The main function for calculating chemical shifts using shifty++
-    path = The path to the pdb file that need to be calculated (type: str)
-    strict = Strictness level of shift transfer (0 - Strict, 1 - Normal, 2 - Permissive)
-    secondary = Whether or not output secondary shift
-    test = Whether or not use the test BLAST database
-    exclude = Whether or not use the Exclude mode
-    shifty = Whether or not use the SHIFTY mode
-    blast_score_threshold = minimum score reported by BLAST program required to be considered as a candidate alignment
-    e_value_threshold = maximum expectation value reported by BLAST program required to be considered as a candidate alignment
-    long_Tmatch_threshold = the minimum total length of the matched sequence for applying long_match_percent_threshold
-    long_match_percent_threshold = minimum percentage coverage of the exact matching residues with the matched sequence for a long match
-    short_Tmatch_threshold = the minimum total length of the matched sequence for applying short_match_percent_threshold
-    short_match_percent_threshold = minimum percentage coverage of the exact matching residues with the matched sequence for a short match
-    TMscore_threshold = minimum mTM-align score required to be considered as a good alignment
-    rmsd_threshold = maximum RMSD from mTM-align permitted between two alignment
-    coverage_threshold = minimum coverage for mTM-align candidates to be considered in final shift transfer
-    refDB_shifts_path = path to all the csv file storing the refDB shifts
-    custom_working_dir = when specified, use this folder to process blast and mTM-align
 
-    returns a pandas.DataFrame containing all the calculated shifts
-    '''
-    fixname=os.path.basename(path).replace(".pdb","_fix.pdb")
-    seq,resnum=chain_to_seq(read_sing_chain_PDB(path))
-    blast_result=blast(seq,db_name="train.blastdb" if test else "refDB.blastdb",return_aligned_seq=True,cleaning=not DEBUG,working_dir=custom_working_dir) # Only the SHIFTY mode needs the aligned sequence
-    candidates=[]
-    for result in blast_result.values():
-        if result.score>=blast_score_threshold and result.Evalue<=e_value_threshold:
-            # Those pass the selection criterion
-            if result.Tmatch>=long_Tmatch_threshold and result.Lmatch/result.Tmatch>=long_match_percent_threshold:
-                # Long matches
-                if not exclude:
-                    candidates.append(result)
-                else:
-                    if not result.coverage > GLOBAL_TEST_CUTOFF:
-                        candidates.append(result)
-            elif result.Tmatch>=short_Tmatch_threshold and result.Lmatch/result.Tmatch>=short_match_percent_threshold:
-                # Short matches
-                if not exclude:
-                    candidates.append(result)
-                else:
-                    if not result.coverage > GLOBAL_TEST_CUTOFF:
-                        candidates.append(result)
-                
-    if len(candidates)==0:
-        residues=toolbox.decode_seq(seq)
-        result_dict={"RESNAME":residues,"RESNUM":resnum}
-        df=pd.DataFrame(result_dict)
+# ── Main prediction entry point ───────────────────────────────────────────────
+
+def main(
+    path: str,
+    strict: int,
+    secondary: bool = False,
+    test: bool = False,
+    exclude: bool = False,
+    shifty: bool = False,
+    blast_score_threshold: float = 0,
+    e_value_threshold: float = 1e-10,
+    long_Tmatch_threshold: int = 40,
+    short_Tmatch_threshold: int = 20,
+    long_match_percent_threshold: float = 0.15,
+    short_match_percent_threshold: float = 0.4,
+    TMscore_threshold: float = 0.8,
+    rmsd_threshold: float = 1.75,
+    coverage_threshold: float = 0.3,
+    refDB_shifts_path: Optional[str] = None,
+    custom_working_dir: Optional[str] = None,
+) -> pd.DataFrame:
+    """Calculate chemical shifts for a single PDB file using UCBShift-Y (SHIFTY++).
+
+    Returns a DataFrame with predicted chemical shifts and alignment quality metrics.
+    """
+    if refDB_shifts_path is None:
+        refDB_shifts_path = str(SCRIPT_PATH / "refDB" / "shifts_df") + "/"
+
+    fixname = os.path.basename(path).replace(".pdb", "_fix.pdb")
+    seq, resnum = chain_to_seq(read_sing_chain_PDB(path))
+    db_name = "train.blastdb" if test else "refDB.blastdb"
+    blast_results = blast(seq, db_name=db_name, return_aligned_seq=True,
+                          cleaning=not DEBUG, working_dir=custom_working_dir)
+
+    def _empty_result() -> pd.DataFrame:
+        residues = toolbox.decode_seq(str(seq))
+        df = pd.DataFrame({"RESNAME": residues, "RESNUM": resnum})
         for atom in toolbox.ATOMS:
-            df[atom]=np.nan           
+            df[atom] = np.nan
+            df[f"{atom}_BEST_REF_SCORE"] = 0
+            df[f"{atom}_BEST_REF_COV"] = 0
+            df[f"{atom}_BEST_REF_MATCH"] = 0
+        return df
+
+    candidates = []
+    for result in blast_results.values():
+        if result.score >= blast_score_threshold and result.Evalue <= e_value_threshold:
+            long_ok = (result.Tmatch >= long_Tmatch_threshold
+                       and result.Lmatch / result.Tmatch >= long_match_percent_threshold)
+            short_ok = (result.Tmatch >= short_Tmatch_threshold
+                        and result.Lmatch / result.Tmatch >= short_match_percent_threshold)
+            if long_ok or short_ok:
+                if not exclude or not result.coverage > GLOBAL_TEST_CUTOFF:
+                    candidates.append(result)
+
+    if not candidates:
         print("No sequence in database generates possible alignments")
         if os.path.exists(fixname):
             os.remove(fixname)
-        for atom in toolbox.ATOMS:
-            df[atom]=np.nan     
-            df[atom+"_BEST_REF_SCORE"]=0
-            df[atom+"_BEST_REF_COV"]=0
-            df[atom+"_BEST_REF_MATCH"]=0
-        return df
-    final=[]
-    identities=[]
+        return _empty_result()
+
+    final = []
+    identities = []
+
     if shifty:
-        # In SHIFTY mode, do not do structural alignment
-        best_match=np.argmax([item.score for item in candidates])
+        best_match = int(np.argmax([item.score for item in candidates]))
         final.append(candidates[best_match])
         identities.append(candidates[best_match].coverage)
         if os.path.exists(fixname):
             os.remove(fixname)
     else:
-        # Do mTM alignment
-        candidates=[item.target_name for item in candidates]
+        candidate_names = [item.target_name for item in candidates]
+        source_pdb = fixname if os.path.exists(fixname) else path
+        mtm_results = mTM_align(source_pdb, candidate_names,
+                                 cleaning=not DEBUG, working_dir=custom_working_dir)
         if os.path.exists(fixname):
-            mtm_results=mTM_align(fixname,candidates,cleaning=not DEBUG,working_dir=custom_working_dir)  
             os.remove(fixname)
-        else:
-            mtm_results=mTM_align(path,candidates,cleaning=not DEBUG,working_dir=custom_working_dir) 
-        blast_scores=[]
+
+        blast_scores = []
         for result in mtm_results.values():
-            if result.TMscore>TMscore_threshold and result.rmsd<rmsd_threshold and result.coverage>coverage_threshold:
-                identity=blast_result[result.target_name].coverage
+            if (result.TMscore > TMscore_threshold
+                    and result.rmsd < rmsd_threshold
+                    and result.coverage > coverage_threshold):
+                identity = blast_results[result.target_name].coverage
                 final.append(result)
                 identities.append(identity)
-                blast_scores.append(blast_result[result.target_name].score)
-        # Calculate normalized blast scores so that it can be considered together with TM scores
-        if len(blast_scores)>0:
-            normalized_blast_scores=np.array(blast_scores)/np.max(blast_scores)
-    if len(final)==0:
-        residues=toolbox.decode_seq(seq)
-        result_dict={"RESNAME":residues,"RESNUM":resnum}
-        df=pd.DataFrame(result_dict)
+                blast_scores.append(blast_results[result.target_name].score)
+        if blast_scores:
+            normalized_blast_scores = np.array(blast_scores) / np.max(blast_scores)
+
+    if not final:
         print("No significant structure alignment is possible!")
-        for atom in toolbox.ATOMS:
-            df[atom]=np.nan           
-            df[atom+"_BEST_REF_SCORE"]=0
-            df[atom+"_BEST_REF_COV"]=0
-            df[atom+"_BEST_REF_MATCH"]=0
-        return df
-    print("Calculating using %d references with maximal identity %.2f"%(len(final),np.max(identities)))
-    refDB={}
-    for item in final:
-        refDB[item.target_name]=pd.read_csv(refDB_shifts_path+item.target_name+".csv")
-    # changed candidate.source_seq->seq
-    candidate_shifts=[assign_aligned_shifts(seq,candidate.target_seq,candidate.target_name,refDB[candidate.target_name],strict) for candidate in final]
+        return _empty_result()
+
+    print(f"Calculating using {len(final)} references with maximal identity {np.max(identities):.2f}")
+
+    refDB = {item.target_name: pd.read_csv(f"{refDB_shifts_path}{item.target_name}.csv")
+             for item in final}
+    seq_str = str(seq)
+    candidate_shifts = [
+        assign_aligned_shifts(seq_str, candidate.target_seq, candidate.target_name,
+                               refDB[candidate.target_name], strict)
+        for candidate in final
+    ]
+
     if shifty:
-        scores=[1]
+        scores = [1.0]
     else:
-        scores=[candidate.TMscore*normalized_blast_scores[idx] for idx,candidate in enumerate(final)]
-    seq_shifts=[]
-    # Fix problems when the sequence read by Biopython is not the same as the sequence generated by mTM-align
-    mtm_recognized_seq=final[0].source_seq.replace("-","")
-    if not shifty and mtm_recognized_seq!=str(seq):
-        biopython_seq,mtm_seq=Needleman_Wunsch_alignment(str(seq),mtm_recognized_seq)
-        biopython_seq=list(biopython_seq)
-        for i in range(len(mtm_seq)):
-           if mtm_seq[i]=="-" and biopython_seq[i]!="-":
-               biopython_seq[i]="x" # Marked for deletion
-        biopython_seq="".join(biopython_seq)
-        biopython_seq.replace("-","") 
-        seq=""
-        old_resnum=resnum
-        resnum=[]
-        for i in range(len(biopython_seq)):
-            if biopython_seq[i]!="x":
-                seq+=biopython_seq[i]
-                resnum.append(old_resnum[i])
-    for i in range(len(seq)):
-        resname=toolbox.decode_seq(seq[i])
-        next_pro=False
-        if i+1<len(resnum) and resnum[i+1]==resnum[i]+1:
-            if seq[i+1]=="P": # the next residue in the query protein is proline
-                next_pro=True
-        residue_shifts={}
-        residue_shifts["RESNAME"]=resname
-        residue_shifts["RESNUM"]=resnum[i]
+        scores = [candidate.TMscore * normalized_blast_scores[idx]
+                  for idx, candidate in enumerate(final)]
+
+    # Reconcile biopython sequence with mTM-align sequence
+    if not shifty:
+        mtm_recognized_seq = final[0].source_seq.replace("-", "")
+        if mtm_recognized_seq != seq_str:
+            bp_seq, mtm_seq = Needleman_Wunsch_alignment(seq_str, mtm_recognized_seq)
+            bp_seq_list = list(bp_seq)
+            for i, m in enumerate(mtm_seq):
+                if m == "-" and bp_seq_list[i] != "-":
+                    bp_seq_list[i] = "x"
+            bp_seq_cleaned = "".join(bp_seq_list).replace("-", "")
+            old_resnum = resnum
+            seq_str = ""
+            resnum = []
+            for i, ch in enumerate(bp_seq_cleaned):
+                if ch != "x":
+                    seq_str += ch
+                    resnum.append(old_resnum[i])
+
+    seq_shifts = []
+    for i, (char, rnum) in enumerate(zip(seq_str, resnum)):
+        resname = toolbox.decode_seq(char)
+        next_pro = (
+            i + 1 < len(resnum)
+            and resnum[i + 1] == rnum + 1
+            and seq_str[i + 1] == "P"
+        )
+        residue_shifts: dict = {"RESNAME": resname, "RESNUM": rnum}
         for atom in toolbox.ATOMS:
-            shifts=[]
-            reference_scores=[]
-            res_scores=[] # probably need to do some non-linear conversion of the scores
-            for candidate_shift,score in zip(candidate_shifts,scores):
-                if atom in candidate_shift[i] and not np.isnan(candidate_shift[i][atom]):
-                    shifts.append(candidate_shift[i][atom])
-                    target_score=np.exp(score*5)*np.exp(get_blosum_value(candidate_shift[i]["SOURCE_RESNAME"],candidate_shift[i]["TARGET_RESNAME"]))
+            shifts, res_scores, reference_scores = [], [], []
+            for cshift, score in zip(candidate_shifts, scores):
+                entry = cshift[i]
+                if atom in entry and not np.isnan(entry[atom]):
+                    blosum_bonus = get_blosum_value(entry["SOURCE_RESNAME"], entry["TARGET_RESNAME"])
+                    target_score = np.exp(score * 5) * np.exp(blosum_bonus)
+                    shifts.append(entry[atom])
                     res_scores.append(target_score)
                     reference_scores.append(target_score)
                 else:
                     reference_scores.append(0)
-            if len(shifts)>0:
-                # calculate weighted average for the specific residue based on mTM alignment scores and BLOSUM numbers
-                rc_diff=np.sum(np.array(shifts)*np.array(res_scores))/np.sum(res_scores)
-                # capping rc_diff to prevent making crazy errors due to bad database records
-                rc_diff = min(rc_diff, SS_CAPS[atom])
-                rc_diff = max(rc_diff, -SS_CAPS[atom])
-                if next_pro:
-                    if secondary:
-                        residue_shifts[atom]=rc_diff
-                        residue_shifts[atom+"_RC"]=randcoil_pro[atom][resname]
-                    else:
-                        residue_shifts[atom]=rc_diff+randcoil_pro[atom][resname]
+
+            if shifts:
+                rc_diff = np.sum(np.array(shifts) * np.array(res_scores)) / np.sum(res_scores)
+                rc_diff = np.clip(rc_diff, -SS_CAPS[atom], SS_CAPS[atom])
+                rc_table = randcoil_pro if next_pro else randcoil_ala
+                if secondary:
+                    residue_shifts[atom] = rc_diff
+                    residue_shifts[f"{atom}_RC"] = rc_table[atom][resname]
                 else:
-                    if secondary:
-                        residue_shifts[atom]=rc_diff
-                        residue_shifts[atom+"_RC"]=randcoil_ala[atom][resname]
-                    else:
-                        residue_shifts[atom]=rc_diff+randcoil_ala[atom][resname]
+                    residue_shifts[atom] = rc_diff + rc_table[atom][resname]
             else:
-                residue_shifts[atom]=np.nan
-            max_ref = np.argmax(reference_scores)
-            if reference_scores[max_ref]>0:
-                residue_shifts[atom+"_BEST_REF_SCORE"]=final[max_ref].TMscore * np.exp(-final[max_ref].rmsd) 
-                residue_shifts[atom+"_BEST_REF_COV"]=min(final[max_ref].coverage,identities[max_ref])
-                residue_shifts[atom+"_BEST_REF_MATCH"]=int(candidate_shifts[max_ref][i]["SOURCE_RESNAME"] == candidate_shifts[max_ref][i]["TARGET_RESNAME"])
+                residue_shifts[atom] = np.nan
+
+            max_ref = int(np.argmax(reference_scores))
+            if reference_scores[max_ref] > 0:
+                best = final[max_ref]
+                residue_shifts[f"{atom}_BEST_REF_SCORE"] = best.TMscore * np.exp(-best.rmsd)
+                residue_shifts[f"{atom}_BEST_REF_COV"] = min(best.coverage, identities[max_ref])
+                residue_shifts[f"{atom}_BEST_REF_MATCH"] = int(
+                    candidate_shifts[max_ref][i].get("SOURCE_RESNAME")
+                    == candidate_shifts[max_ref][i].get("TARGET_RESNAME")
+                )
             else:
-                residue_shifts[atom+"_BEST_REF_SCORE"]=0
-                residue_shifts[atom+"_BEST_REF_COV"]=0
-                residue_shifts[atom+"_BEST_REF_MATCH"]=0
+                residue_shifts[f"{atom}_BEST_REF_SCORE"] = 0
+                residue_shifts[f"{atom}_BEST_REF_COV"] = 0
+                residue_shifts[f"{atom}_BEST_REF_MATCH"] = 0
         seq_shifts.append(residue_shifts)
-    result=pd.DataFrame(seq_shifts)
-    # result=result[["RESNUM", "RESNAME"] + toolbox.ATOMS + ["MAX_IDENTITY", "AVG_IDENTITY"]]
-    return result
 
-if __name__=="__main__":
-    args=argparse.ArgumentParser(description="This program executes both sequence-based alignment (using BLAST) and structure-based alignment (using mTM-align) to find the best alignment for a specific pdb file with entities in the refDB database, and use the average chemical shifts from refDB to predict the chemical shifts for backbone H/C/N atom chemical shifts for the query protein")
-    args.add_argument("input",help="The query PDB file for which the shifts are calculated")
-    args.add_argument("--output", "-o",help="Filename of generated output file. A file [shifts.csv] is generated by default",default="shifts.csv")
-    args.add_argument("--strict","-s",help="Strict level of shift transfer:\n\t0 - Strict, only the exact matching residue shifts are transferred\n\t1 - Normal, transfer the shifts for residues that are the same or have positive substitution scores (from BLOSUM62)\n\t2 - Permissive, transfer all shifts regardless of the likeliness of substitution.",type=int,default=1)
-    args.add_argument("--secondary","-2",help="If this flag is set, the output will be secondary shifts (observed shifts-random coil shifts) instead of observed shifts",action="store_true",default=False)
-    args.add_argument("--test","-t",help="If this flag is set, the test BLAST database is used, which means all sequences in the validation set and test set will not be included in the BLAST search database",action="store_true",default=False)
-    args.add_argument("--exclude","-e",help="Exclude mode, another way of analyzing the performance of SHIFTY++. When selecting sequences going to the structure alignment, those completely identical examples are excluded.",action="store_true",default=False)
-    args.add_argument("--shifty","-y",help="SHIFTY mode, only the top hit from sequence alignment is considered for shift transfer",action="store_true",default=False)
-    args=args.parse_args()
-    result=main(args.input,strict=args.strict,secondary=args.secondary,test=args.test,exclude=args.exclude,shifty=args.shifty)  
-    result.to_csv(args.output,index=None)
+    return pd.DataFrame(seq_shifts)
 
 
+# ── CLI ───────────────────────────────────────────────────────────────────────
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "UCBShift-Y: predict NMR chemical shifts by transferring shifts from "
+            "similar proteins in refDB via sequence (BLAST) and structure (mTM-align) alignment."
+        )
+    )
+    parser.add_argument("input", help="Query PDB file")
+    parser.add_argument("--output", "-o", default="shifts.csv", help="Output CSV file")
+    parser.add_argument(
+        "--strict", "-s", type=int, default=1,
+        help="Strictness: 0=exact match, 1=BLOSUM62>0, 2=permissive",
+    )
+    parser.add_argument("--secondary", "-2", action="store_true",
+                        help="Output secondary shifts (observed minus random coil)")
+    parser.add_argument("--test", "-t", action="store_true",
+                        help="Use the test BLAST database")
+    parser.add_argument("--exclude", "-e", action="store_true",
+                        help="Exclude mode: skip near-identical reference sequences")
+    parser.add_argument("--shifty", "-y", action="store_true",
+                        help="SHIFTY mode: use only the top BLAST hit")
+    args = parser.parse_args()
+    result = main(args.input, strict=args.strict, secondary=args.secondary,
+                  test=args.test, exclude=args.exclude, shifty=args.shifty)
+    result.to_csv(args.output, index=False)


### PR DESCRIPTION
- Fix biopython API breakage: Bio.SubsMat.MatrixInfo.blosum62 removed in biopython 1.78; replace with substitution_matrices.load("BLOSUM62") and update all BLOSUM lookups to use the Array API
- Fix Bio.SeqUtils.IUPACData moved to Bio.Data.IUPACData (biopython 1.80); guarded with try/except for backwards compatibility
- Fix PairwiseAligner output parsing: replace fragile str(alignment).split("\n") index with format(alignment) token-based parsing of labelled target/query lines
- Fix PDB.Polypeptide.three_to_one() deprecated removal; use local dict lookup
- Fix DataFrame.append() removed in pandas 2.0; replace with pd.concat()
- Add missing featsq() function (called by sx2_dprep/sp_dprep but never defined)
- Remove hardcoded developer machine paths from data_prep_functions.py
- Replace % string formatting with f-strings throughout
- Add type hints to all public functions
- Use pathlib.Path for file paths
- Explicit imports in CSpred.py replacing wildcard import
- Update requirements.txt to modern version ranges